### PR TITLE
Add data to heartbeat message

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -153,7 +153,7 @@ loop:
 			c.Response().Flush()
 			deliveredMessagesMetric.Inc()
 		case <-ticker.C:
-			_, err = fmt.Fprintf(c.Response(), "event: heartbeat\n\n")
+			_, err = fmt.Fprintf(c.Response(), "event: heartbeat\ndata: \n\n")
 			if err != nil {
 				log.Errorf("ticker can't write to connection: %v", err)
 				break loop

--- a/handler.go
+++ b/handler.go
@@ -153,7 +153,7 @@ loop:
 			c.Response().Flush()
 			deliveredMessagesMetric.Inc()
 		case <-ticker.C:
-			_, err = fmt.Fprintf(c.Response(), "event: heartbeat\ndata: \n\n")
+			_, err = fmt.Fprintf(c.Response(), "event: message\ndata: heartbeat\n\n")
 			if err != nil {
 				log.Errorf("ticker can't write to connection: %v", err)
 				break loop


### PR DESCRIPTION
We can't access heartbeat events right now, because the heartbeat without a data section breaks the specification https://html.spec.whatwg.org/multipage/server-sent-events.html#dispatchMessage