### PR TITLE
fix sent message log entry

### DIFF
--- a/datatype/datatype.go
+++ b/datatype/datatype.go
@@ -3,6 +3,7 @@ package datatype
 type SseMessage struct {
 	EventId int64
 	Message []byte
+	To      string
 }
 
 type BridgeMessage struct {

--- a/storage/memory/storage.go
+++ b/storage/memory/storage.go
@@ -104,10 +104,10 @@ func (s *Storage) GetMessages(ctx context.Context, keys []string, lastEventId in
 	return results, nil
 }
 
-func (s *Storage) Add(ctx context.Context, key string, ttl int64, mes datatype.SseMessage) error {
+func (s *Storage) Add(ctx context.Context, mes datatype.SseMessage, ttl int64) error {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 
-	s.db[key] = append(s.db[key], message{SseMessage: mes, expireAt: time.Now().Add(time.Duration(ttl) * time.Second)})
+	s.db[mes.To] = append(s.db[mes.To], message{SseMessage: mes, expireAt: time.Now().Add(time.Duration(ttl) * time.Second)})
 	return nil
 }

--- a/storage/memory/storage_test.go
+++ b/storage/memory/storage_test.go
@@ -64,10 +64,10 @@ func Test_removeExpiredMessages(t *testing.T) {
 
 func TestStorage(t *testing.T) {
 	s := &Storage{db: map[string][]message{}}
-	s.Add(context.Background(), "1", 2, datatype.SseMessage{EventId: 1})
-	s.Add(context.Background(), "2", 2, datatype.SseMessage{EventId: 2})
-	s.Add(context.Background(), "2", 2, datatype.SseMessage{EventId: 3})
-	s.Add(context.Background(), "1", 2, datatype.SseMessage{EventId: 4})
+	s.Add(context.Background(), datatype.SseMessage{EventId: 1, To: "1"}, 2)
+	s.Add(context.Background(), datatype.SseMessage{EventId: 2, To: "2"}, 2)
+	s.Add(context.Background(), datatype.SseMessage{EventId: 3, To: "2"}, 2)
+	s.Add(context.Background(), datatype.SseMessage{EventId: 4, To: "1"}, 2)
 	tests := []struct {
 		name        string
 		keys        []string
@@ -78,8 +78,8 @@ func TestStorage(t *testing.T) {
 			name: "one key",
 			keys: []string{"1"},
 			want: []datatype.SseMessage{
-				{EventId: 1},
-				{EventId: 4},
+				{EventId: 1, To: "1"},
+				{EventId: 4, To: "1"},
 			},
 		},
 		{
@@ -91,10 +91,10 @@ func TestStorage(t *testing.T) {
 			name: "get all keys",
 			keys: []string{"1", "2"},
 			want: []datatype.SseMessage{
-				{EventId: 1},
-				{EventId: 4},
-				{EventId: 2},
-				{EventId: 3},
+				{EventId: 1, To: "1"},
+				{EventId: 4, To: "1"},
+				{EventId: 2, To: "2"},
+				{EventId: 3, To: "2"},
 			},
 		},
 	}

--- a/storage/pg/storage.go
+++ b/storage/pg/storage.go
@@ -149,7 +149,7 @@ func (s *Storage) worker() {
 	}
 }
 
-func (s *Storage) Add(ctx context.Context, key string, ttl int64, mes datatype.SseMessage) error {
+func (s *Storage) Add(ctx context.Context, mes datatype.SseMessage, ttl int64) error {
 	_, err := s.postgres.Exec(ctx, `
 		INSERT INTO bridge.messages
 		(
@@ -159,7 +159,7 @@ func (s *Storage) Add(ctx context.Context, key string, ttl int64, mes datatype.S
 		bridge_message
 		)
 		VALUES ($1, $2, to_timestamp($3), $4)
-	`, key, mes.EventId, time.Now().Add(time.Duration(ttl)*time.Second).Unix(), mes.Message)
+	`, mes.To, mes.EventId, time.Now().Add(time.Duration(ttl)*time.Second).Unix(), mes.Message)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
- We listen messages via ` curl --raw  "http://localhost:8081/bridge/events?client_id=user1,user2,user3&heartbeat=message"`.
- And sending via `curl -X POST "http://localhost:8081/bridge/message?client_id=sender-123&to=user1&ttl=300" -H "Content-Type: text/plain" -d "Hello from bridge"
{"message":"OK","statusCode":200}`

how it was before:

```
DEBU[0017] message sent event_id=1755776068264841 from=sender-123 hash=3f2669d178361bb28c90fd7fd0ca6e60ca317ae70761729f379c168dedec40aa to="user1,user2,user3"
```

How it is now:

```
DEBU[0006] message sent event_id=1755776106144029 from=sender-123 hash=3f2669d178361bb28c90fd7fd0ca6e60ca317ae70761729f379c168dedec40aa to=user1
```