### PR TITLE
add no_request_source param

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -130,7 +130,7 @@ func (h *handler) EventRegistrationHandler(c echo.Context) error {
 	}
 
 	enableQueueDoneEvent := false
-	if queueDoneParam, exists := paramsStore.Get("enable_queue_done_event"); exists && queueDoneParam == "true" {
+	if queueDoneParam, exists := paramsStore.Get("enable_queue_done_event"); exists && strings.ToLower(queueDoneParam) == "true" {
 		enableQueueDoneEvent = true
 	}
 
@@ -328,7 +328,7 @@ func (h *handler) SendMessageHandler(c echo.Context) error {
 
 	var requestSource string
 	noRequestSourceParam, ok := params["no_request_source"]
-	enableRequestSource := !ok || len(noRequestSourceParam) == 0 || noRequestSourceParam[0] != "true"
+	enableRequestSource := !ok || len(noRequestSourceParam) == 0 || strings.ToLower(noRequestSourceParam[0]) != "true"
 
 	if enableRequestSource {
 		origin := ExtractOrigin(c.Request().Header.Get("Origin"))

--- a/handler.go
+++ b/handler.go
@@ -352,14 +352,12 @@ func (h *handler) SendMessageHandler(c echo.Context) error {
 		requestSource = encryptedRequestSource
 	}
 
-	bridgeMessage := datatype.BridgeMessage{
+	mes, err := json.Marshal(datatype.BridgeMessage{
 		From:                clientId[0],
 		Message:             string(message),
-		TraceId:             traceId,
 		BridgeRequestSource: requestSource,
-	}
-
-	mes, err := json.Marshal(bridgeMessage)
+		TraceId:             traceId,
+	})
 	if err != nil {
 		badRequestMetric.Inc()
 		log.Error(err)

--- a/handler.go
+++ b/handler.go
@@ -327,8 +327,8 @@ func (h *handler) SendMessageHandler(c echo.Context) error {
 	}
 
 	var requestSource string
-	noRequestSourceParam, hasNoRequestSource := params["no_request_source"]
-	enableRequestSource := !hasNoRequestSource || len(noRequestSourceParam) == 0 || noRequestSourceParam[0] != "true"
+	noRequestSourceParam, ok := params["no_request_source"]
+	enableRequestSource := !ok || len(noRequestSourceParam) == 0 || noRequestSourceParam[0] != "true"
 
 	if enableRequestSource {
 		origin := ExtractOrigin(c.Request().Header.Get("Origin"))


### PR DESCRIPTION
test it locally with debug msgs, not included in PR:

```
diff --git a/handler.go b/handler.go
index 13d7af8..2b32508 100644
--- a/handler.go
+++ b/handler.go
@@ -329,6 +329,7 @@ func (h *handler) SendMessageHandler(c echo.Context) error {
        var requestSource string
        noRequestSourceParam, ok := params["no_request_source"]
        enableRequestSource := !ok || len(noRequestSourceParam) == 0 || strings.ToLower(noRequestSourceParam[0]) != "true"
+       log.Debugf("no_request_source: %v, enableRequestSource: %v", noRequestSourceParam, enableRequestSource)
 
        if enableRequestSource {
                origin := ExtractOrigin(c.Request().Header.Get("Origin"))
@@ -350,6 +351,7 @@ func (h *handler) SendMessageHandler(c echo.Context) error {
                        return c.JSON(HttpResError(fmt.Sprintf("failed to encrypt request source: %v", err), http.StatusBadRequest))
                }
                requestSource = encryptedRequestSource
+               log.Debugf("request source encrypted: %s", requestSource)
        }
 
        mes, err := json.Marshal(datatype.BridgeMessage{
```

Logs:

```
➜  bridge git:(no_request_source) ✗ LOG_LEVEL=debug ./bridge
INFO[0000] Bridge is running                            

   ____    __
  / __/___/ /  ___
 / _// __/ _ \/ _ \
/___/\__/_//_/\___/ v4.9.0
High performance, minimalist Go web framework
https://echo.labstack.com
____________________________________O/_______
                                    O\
⇨ http server started on [::]:8081
DEBU[0002] no_request_source: [true], enableRequestSource: false  prefix=SendMessageHandler
DEBU[0002] message received                              event_id=1757084476964629 from=68a2f44a77a4188a907d40388702040cf0b92348d8139004b7e15cdffa80c171 hash=ae613c8fff2caaa9b5c1293260600149c51acaa6e5a447076d4789b1457ab5dc prefix=SendMessageHandler to=bd022a1690350292cb171ba3d5eb545f022a6c1f010e3bf534feba8222ea1c34 trace_id=01991a65-6df9-7ed4-8f9a-28c4122c2c70
{"time":"2025-09-05T17:01:18.970286+02:00","id":"","remote_ip":"::1","host":"localhost:8081","method":"POST","uri":"/bridge/message?client_id=68a2f44a77a4188a907d40388702040cf0b92348d8139004b7e15cdffa80c171&to=bd022a1690350292cb171ba3d5eb545f022a6c1f010e3bf534feba8222ea1c34&ttl=300&topic=sendTransaction&no_request_source=true","user_agent":"curl/8.7.1","status":200,"error":"","latency":336083,"latency_human":"336.083µs","bytes_in":17,"bytes_out":34}
DEBU[0032] no_request_source: [false], enableRequestSource: true  prefix=SendMessageHandler
DEBU[0032] request source encrypted: 6VRIW6IhxIv43Oxk2GBeXvfJzDn0JwilGQTVLRvvBBjRmVqpVVQwYXXItXIgEfsNSuT8zi9JVomX/chAZNZb0CtJG2JvNm+qUnN6IhQye45hgoM24OLAVICqkKUdwAQqQXf7r41fWaId1+lmc4sMZdB3Snp8oA==  prefix=SendMessageHandler
DEBU[0032] message received                              event_id=1757084476964630 from=68a2f44a77a4188a907d40388702040cf0b92348d8139004b7e15cdffa80c171 hash=ae613c8fff2caaa9b5c1293260600149c51acaa6e5a447076d4789b1457ab5dc prefix=SendMessageHandler to=bd022a1690350292cb171ba3d5eb545f022a6c1f010e3bf534feba8222ea1c34 trace_id=01991a65-e487-7d81-938b-40ac4bfeeac4
{"time":"2025-09-05T17:01:49.320086+02:00","id":"","remote_ip":"::1","host":"localhost:8081","method":"POST","uri":"/bridge/message?client_id=68a2f44a77a4188a907d40388702040cf0b92348d8139004b7e15cdffa80c171&to=bd022a1690350292cb171ba3d5eb545f022a6c1f010e3bf534feba8222ea1c34&ttl=300&topic=sendTransaction&no_request_source=false","user_agent":"curl/8.7.1","status":200,"error":"","latency":237541,"latency_human":"237.541µs","bytes_in":17,"bytes_out":34}
```

