### PR TITLE
[TON-366] Add antiscam domain filtering feature

### DIFF
--- a/cmd/bridge3/main.go
+++ b/cmd/bridge3/main.go
@@ -14,6 +14,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/ton-connect/bridge/internal"
 	"github.com/ton-connect/bridge/internal/analytics"
+	"github.com/ton-connect/bridge/internal/antiscam"
 	"github.com/ton-connect/bridge/internal/app"
 	"github.com/ton-connect/bridge/internal/config"
 	bridge_middleware "github.com/ton-connect/bridge/internal/middleware"
@@ -152,7 +153,23 @@ func main() {
 		e.Use(corsConfig)
 	}
 
-	h := handlerv3.NewHandler(dbConn, time.Duration(config.Config.HeartbeatInterval)*time.Second, extractor, timeProvider, collector, analyticsBuilder)
+	var domainChecker antiscam.DomainChecker
+	if config.Config.AntiscamEnabled && config.Config.BlackListedDomainsURL != "" {
+		blocklist := antiscam.NewBlocklist(config.Config.BlackListedDomainsURL, time.Duration(config.Config.BlackListRefreshInterval)*time.Second)
+		blocklist.Start(context.Background())
+		defer blocklist.Stop()
+		domainChecker = blocklist
+		log.WithFields(log.Fields{
+			"url":              config.Config.BlackListedDomainsURL,
+			"refresh_interval": config.Config.BlackListRefreshInterval,
+		}).Info("Antiscam domain filtering enabled")
+	} else {
+		domainChecker = &antiscam.NoopChecker{}
+		log.Info("Antiscam domain filtering disabled")
+	}
+	antiscamService := antiscam.NewService(domainChecker)
+
+	h := handlerv3.NewHandler(dbConn, time.Duration(config.Config.HeartbeatInterval)*time.Second, extractor, timeProvider, collector, analyticsBuilder, antiscamService)
 
 	e.GET("/bridge/events", h.EventRegistrationHandler)
 	e.POST("/bridge/message", h.SendMessageHandler)

--- a/internal/antiscam/README.md
+++ b/internal/antiscam/README.md
@@ -1,12 +1,12 @@
 # Antiscam Domain Filtering
 
-Silently blocks scam domains from using the bridge. Blocked clients receive fake success responses (pushes) or garbage data (SSE), so they cannot distinguish filtering from normal operation.
+Blocks scam domains from using the bridge. Push requests receive a fake success response so the client cannot distinguish filtering from normal delivery; SSE connections are closed immediately with `403 Forbidden`.
 
 ## How It Works
 
 1. **Blocklist loading** — Fetches a newline-separated domain list from a remote URL on startup and refreshes it periodically in the background.
 2. **Push dropping** — `SendMessageHandler` checks the `Origin` header. If blocked, returns `200 OK` without delivering the message.
-3. **SSE poisoning** — `EventRegistrationHandler` checks the `Origin` header. If blocked, sends random hex-encoded garbage as SSE events at random 2-15s intervals instead of creating a real session. No session, no storage subscription — zero resource waste beyond the connection itself.
+3. **SSE rejection** — `EventRegistrationHandler` checks the `Origin` header. If blocked, returns `403 Forbidden` and closes the connection without creating a session or subscribing to storage.
 
 ## Subdomain Matching
 
@@ -38,6 +38,6 @@ phishing.net
 | Metric | Type | Description |
 |---|---|---|
 | `antiscam_blocked_pushes_total` | Counter | Push messages silently dropped |
-| `antiscam_poisoned_connections_total` | Counter | SSE connections poisoned |
+| `antiscam_blocked_connections_total` | Counter | SSE connections rejected |
 | `antiscam_blocklist_size` | Gauge | Current number of domains in the blocklist |
 | `antiscam_blocklist_refresh_errors_total` | Counter | Blocklist refresh failures |

--- a/internal/antiscam/README.md
+++ b/internal/antiscam/README.md
@@ -1,0 +1,43 @@
+# Antiscam Domain Filtering
+
+Silently blocks scam domains from using the bridge. Blocked clients receive fake success responses (pushes) or garbage data (SSE), so they cannot distinguish filtering from normal operation.
+
+## How It Works
+
+1. **Blocklist loading** — Fetches a newline-separated domain list from a remote URL on startup and refreshes it periodically in the background.
+2. **Push dropping** — `SendMessageHandler` checks the `Origin` header. If blocked, returns `200 OK` without delivering the message.
+3. **SSE poisoning** — `EventRegistrationHandler` checks the `Origin` header. If blocked, sends random hex-encoded garbage as SSE events at random 2-15s intervals instead of creating a real session. No session, no storage subscription — zero resource waste beyond the connection itself.
+
+## Subdomain Matching
+
+The blocklist matches against the full domain hierarchy. Adding `evil.com` to the list also blocks `sub.evil.com`, `deep.sub.evil.com`, etc.
+
+## Configuration
+
+| Variable | Default | Description |
+|---|---|---|
+| `ANTISCAM_ENABLED` | `false` | Enable antiscam filtering |
+| `BLACK_LISTED_DOMAINS_URL` | _(empty)_ | URL to fetch the domain blocklist from |
+| `BLACK_LIST_REFRESH_INTERVAL` | `600` | Blocklist refresh interval in seconds |
+
+Both `ANTISCAM_ENABLED=true` and a non-empty `BLACK_LISTED_DOMAINS_URL` are required to activate filtering. Otherwise a no-op checker is used.
+
+## Blocklist Format
+
+Plain text, one domain per line. Empty lines and lines starting with `#` are ignored. Matching is case-insensitive.
+
+```
+# Scam domains
+evil.com
+scam.org
+phishing.net
+```
+
+## Metrics
+
+| Metric | Type | Description |
+|---|---|---|
+| `antiscam_blocked_pushes_total` | Counter | Push messages silently dropped |
+| `antiscam_poisoned_connections_total` | Counter | SSE connections poisoned |
+| `antiscam_blocklist_size` | Gauge | Current number of domains in the blocklist |
+| `antiscam_blocklist_refresh_errors_total` | Counter | Blocklist refresh failures |

--- a/internal/antiscam/blocklist.go
+++ b/internal/antiscam/blocklist.go
@@ -71,7 +71,17 @@ func (b *Blocklist) IsBlocked(origin string) bool {
 		return false
 	}
 
-	host := extractHost(origin)
+	var host string
+	u, err := url.Parse(origin)
+	if err == nil && u.Host != "" {
+		host = u.Hostname()
+	} else {
+		host = origin
+		if idx := strings.LastIndex(host, ":"); idx != -1 && host[:idx] != "" {
+			host = host[:idx]
+		}
+	}
+
 	if host == "" {
 		return false
 	}
@@ -89,23 +99,6 @@ func (b *Blocklist) IsBlocked(origin string) bool {
 		}
 	}
 	return false
-}
-
-func extractHost(origin string) string {
-	u, err := url.Parse(origin)
-	if err == nil && u.Host != "" {
-		host := u.Hostname() // strips port
-		return host
-	}
-	// fallback: treat as bare host, strip port
-	host := origin
-	if idx := strings.LastIndex(host, ":"); idx != -1 {
-		h := host[:idx]
-		if h != "" {
-			return h
-		}
-	}
-	return host
 }
 
 func (b *Blocklist) refresh(ctx context.Context) {

--- a/internal/antiscam/blocklist.go
+++ b/internal/antiscam/blocklist.go
@@ -124,7 +124,7 @@ func (b *Blocklist) refresh(ctx context.Context) {
 		log.Warnf("failed to fetch blocklist: %v", err)
 		return
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 
 	if resp.StatusCode != http.StatusOK {
 		BlocklistRefreshErrorsMetric.Inc()

--- a/internal/antiscam/blocklist.go
+++ b/internal/antiscam/blocklist.go
@@ -1,0 +1,156 @@
+package antiscam
+
+import (
+	"bufio"
+	"context"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+// DomainChecker checks whether an origin should be blocked.
+type DomainChecker interface {
+	IsBlocked(origin string) bool
+}
+
+// Blocklist fetches a newline-separated domain list from a URL and refreshes it periodically.
+type Blocklist struct {
+	mu              sync.RWMutex
+	domains         map[string]struct{}
+	url             string
+	refreshInterval time.Duration
+	client          *http.Client
+	stopCh          chan struct{}
+}
+
+// NewBlocklist creates a new Blocklist that will fetch domains from the given URL.
+func NewBlocklist(url string, refreshInterval time.Duration) *Blocklist {
+	return &Blocklist{
+		domains:         make(map[string]struct{}),
+		url:             url,
+		refreshInterval: refreshInterval,
+		client:          &http.Client{Timeout: 30 * time.Second},
+		stopCh:          make(chan struct{}),
+	}
+}
+
+// Start performs an initial fetch and starts a background goroutine that refreshes the blocklist.
+func (b *Blocklist) Start(ctx context.Context) {
+	b.refresh(ctx)
+
+	go func() {
+		ticker := time.NewTicker(b.refreshInterval)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-b.stopCh:
+				return
+			case <-ticker.C:
+				b.refresh(ctx)
+			}
+		}
+	}()
+}
+
+// Stop signals the background goroutine to exit.
+func (b *Blocklist) Stop() {
+	close(b.stopCh)
+}
+
+// IsBlocked returns true if the host extracted from origin matches a blocked domain.
+// It walks up the domain hierarchy (e.g. sub.evil.com → evil.com → com).
+func (b *Blocklist) IsBlocked(origin string) bool {
+	if origin == "" {
+		return false
+	}
+
+	host := extractHost(origin)
+	if host == "" {
+		return false
+	}
+
+	host = strings.ToLower(host)
+
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+
+	parts := strings.Split(host, ".")
+	for i := range parts {
+		candidate := strings.Join(parts[i:], ".")
+		if _, ok := b.domains[candidate]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+func extractHost(origin string) string {
+	u, err := url.Parse(origin)
+	if err == nil && u.Host != "" {
+		host := u.Hostname() // strips port
+		return host
+	}
+	// fallback: treat as bare host, strip port
+	host := origin
+	if idx := strings.LastIndex(host, ":"); idx != -1 {
+		h := host[:idx]
+		if h != "" {
+			return h
+		}
+	}
+	return host
+}
+
+func (b *Blocklist) refresh(ctx context.Context) {
+	log := logrus.WithField("prefix", "antiscam.Blocklist")
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, b.url, nil)
+	if err != nil {
+		BlocklistRefreshErrorsMetric.Inc()
+		log.Warnf("failed to create request for blocklist: %v", err)
+		return
+	}
+
+	resp, err := b.client.Do(req)
+	if err != nil {
+		BlocklistRefreshErrorsMetric.Inc()
+		log.Warnf("failed to fetch blocklist: %v", err)
+		return
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		BlocklistRefreshErrorsMetric.Inc()
+		log.Warnf("blocklist fetch returned status %d", resp.StatusCode)
+		return
+	}
+
+	newDomains := make(map[string]struct{})
+	scanner := bufio.NewScanner(resp.Body)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		newDomains[strings.ToLower(line)] = struct{}{}
+	}
+	if err := scanner.Err(); err != nil {
+		BlocklistRefreshErrorsMetric.Inc()
+		log.Warnf("error reading blocklist body: %v", err)
+		return
+	}
+
+	b.mu.Lock()
+	b.domains = newDomains
+	b.mu.Unlock()
+
+	BlocklistSizeMetric.Set(float64(len(newDomains)))
+	log.Infof("blocklist refreshed: %d domains loaded", len(newDomains))
+}

--- a/internal/antiscam/blocklist_test.go
+++ b/internal/antiscam/blocklist_test.go
@@ -1,0 +1,140 @@
+package antiscam
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestBlocklistParsing(t *testing.T) {
+	body := "evil.com\nscam.org\n# comment\n\n  spaces.io  \nMIXED.Case\n"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, body)
+	}))
+	defer srv.Close()
+
+	bl := NewBlocklist(srv.URL, time.Hour)
+	bl.Start(context.Background())
+	defer bl.Stop()
+
+	cases := []struct {
+		origin  string
+		blocked bool
+	}{
+		{"https://evil.com", true},
+		{"https://scam.org", true},
+		{"https://spaces.io", true},
+		{"https://mixed.case", true},
+		{"https://MIXED.CASE", true},
+		{"https://safe.com", false},
+	}
+	for _, tc := range cases {
+		got := bl.IsBlocked(tc.origin)
+		if got != tc.blocked {
+			t.Errorf("IsBlocked(%q) = %v, want %v", tc.origin, got, tc.blocked)
+		}
+	}
+}
+
+func TestBlocklistSubdomainMatching(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, "evil.com\n")
+	}))
+	defer srv.Close()
+
+	bl := NewBlocklist(srv.URL, time.Hour)
+	bl.Start(context.Background())
+	defer bl.Stop()
+
+	cases := []struct {
+		origin  string
+		blocked bool
+	}{
+		{"https://evil.com", true},
+		{"https://sub.evil.com", true},
+		{"https://deep.sub.evil.com", true},
+		{"https://notevil.com", false},
+		{"https://evil.com.safe.org", false},
+		{"", false},
+	}
+	for _, tc := range cases {
+		got := bl.IsBlocked(tc.origin)
+		if got != tc.blocked {
+			t.Errorf("IsBlocked(%q) = %v, want %v", tc.origin, got, tc.blocked)
+		}
+	}
+}
+
+func TestBlocklistOriginExtraction(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, "evil.com\n")
+	}))
+	defer srv.Close()
+
+	bl := NewBlocklist(srv.URL, time.Hour)
+	bl.Start(context.Background())
+	defer bl.Stop()
+
+	cases := []struct {
+		origin  string
+		blocked bool
+	}{
+		{"https://evil.com", true},
+		{"https://evil.com:8080", true},
+		{"http://evil.com/path?q=1", true},
+		{"evil.com", true},
+		{"evil.com:443", true},
+		{"", false},
+	}
+	for _, tc := range cases {
+		got := bl.IsBlocked(tc.origin)
+		if got != tc.blocked {
+			t.Errorf("IsBlocked(%q) = %v, want %v", tc.origin, got, tc.blocked)
+		}
+	}
+}
+
+func TestBlocklistRefreshKeepsOldSetOnFailure(t *testing.T) {
+	var requestCount atomic.Int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		count := requestCount.Add(1)
+		if count == 1 {
+			fmt.Fprint(w, "evil.com\n")
+		} else {
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	}))
+	defer srv.Close()
+
+	bl := NewBlocklist(srv.URL, 50*time.Millisecond)
+	bl.Start(context.Background())
+	defer bl.Stop()
+
+	if !bl.IsBlocked("https://evil.com") {
+		t.Fatal("expected evil.com to be blocked after initial load")
+	}
+
+	// Wait for a failed refresh
+	time.Sleep(150 * time.Millisecond)
+
+	// Old set should still be active
+	if !bl.IsBlocked("https://evil.com") {
+		t.Fatal("expected evil.com to still be blocked after failed refresh")
+	}
+}
+
+func TestNoopChecker(t *testing.T) {
+	checker := &NoopChecker{}
+	if checker.IsBlocked("https://evil.com") {
+		t.Error("NoopChecker should never block")
+	}
+	if checker.IsBlocked("") {
+		t.Error("NoopChecker should never block")
+	}
+}

--- a/internal/antiscam/blocklist_test.go
+++ b/internal/antiscam/blocklist_test.go
@@ -14,7 +14,7 @@ func TestBlocklistParsing(t *testing.T) {
 	body := "evil.com\nscam.org\n# comment\n\n  spaces.io  \nMIXED.Case\n"
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprint(w, body)
+		fmt.Fprint(w, body) //nolint:errcheck
 	}))
 	defer srv.Close()
 
@@ -43,7 +43,7 @@ func TestBlocklistParsing(t *testing.T) {
 
 func TestBlocklistSubdomainMatching(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprint(w, "evil.com\n")
+		fmt.Fprint(w, "evil.com\n") //nolint:errcheck
 	}))
 	defer srv.Close()
 
@@ -72,7 +72,7 @@ func TestBlocklistSubdomainMatching(t *testing.T) {
 
 func TestBlocklistOriginExtraction(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprint(w, "evil.com\n")
+		fmt.Fprint(w, "evil.com\n") //nolint:errcheck
 	}))
 	defer srv.Close()
 
@@ -105,7 +105,7 @@ func TestBlocklistRefreshKeepsOldSetOnFailure(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		count := requestCount.Add(1)
 		if count == 1 {
-			fmt.Fprint(w, "evil.com\n")
+			fmt.Fprint(w, "evil.com\n") //nolint:errcheck
 		} else {
 			w.WriteHeader(http.StatusInternalServerError)
 		}

--- a/internal/antiscam/metrics.go
+++ b/internal/antiscam/metrics.go
@@ -10,9 +10,9 @@ var (
 		Name: "antiscam_blocked_pushes_total",
 		Help: "Total number of push messages silently dropped by antiscam filter",
 	})
-	PoisonedConnectionsMetric = promauto.NewCounter(prometheus.CounterOpts{
-		Name: "antiscam_poisoned_connections_total",
-		Help: "Total number of SSE connections poisoned by antiscam filter",
+	BlockedConnectionsMetric = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "antiscam_blocked_connections_total",
+		Help: "Total number of SSE connections rejected by antiscam filter",
 	})
 	BlocklistSizeMetric = promauto.NewGauge(prometheus.GaugeOpts{
 		Name: "antiscam_blocklist_size",

--- a/internal/antiscam/metrics.go
+++ b/internal/antiscam/metrics.go
@@ -1,0 +1,25 @@
+package antiscam
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var (
+	BlockedPushesMetric = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "antiscam_blocked_pushes_total",
+		Help: "Total number of push messages silently dropped by antiscam filter",
+	})
+	PoisonedConnectionsMetric = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "antiscam_poisoned_connections_total",
+		Help: "Total number of SSE connections poisoned by antiscam filter",
+	})
+	BlocklistSizeMetric = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "antiscam_blocklist_size",
+		Help: "Current number of domains in the antiscam blocklist",
+	})
+	BlocklistRefreshErrorsMetric = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "antiscam_blocklist_refresh_errors_total",
+		Help: "Total number of blocklist refresh failures",
+	})
+)

--- a/internal/antiscam/noop.go
+++ b/internal/antiscam/noop.go
@@ -1,0 +1,9 @@
+package antiscam
+
+// NoopChecker is a DomainChecker that never blocks anything.
+// Used when antiscam filtering is disabled.
+type NoopChecker struct{}
+
+func (n *NoopChecker) IsBlocked(origin string) bool {
+	return false
+}

--- a/internal/antiscam/service.go
+++ b/internal/antiscam/service.go
@@ -57,7 +57,7 @@ func (s *Service) WritePoisonStream(w http.ResponseWriter, flusher http.Flusher,
 		case <-done:
 			return
 		case <-time.After(time.Duration(delay) * time.Second):
-			garbage := make([]byte, 32)
+			garbage := make([]byte, randIntRange(32, 512))
 			_, _ = io.ReadFull(rand.Reader, garbage)
 			data := hex.EncodeToString(garbage)
 			_, err := fmt.Fprintf(w, "event: message\ndata: %s\n\n", data)

--- a/internal/antiscam/service.go
+++ b/internal/antiscam/service.go
@@ -1,0 +1,75 @@
+package antiscam
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"math/big"
+	"net/http"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+// Service provides antiscam filtering for HTTP handlers.
+type Service struct {
+	checker DomainChecker
+}
+
+// NewService creates an antiscam Service backed by the given DomainChecker.
+func NewService(checker DomainChecker) *Service {
+	return &Service{checker: checker}
+}
+
+// CheckPush returns true (and logs + increments metrics) if the origin is blocked.
+// The caller should return 200 OK to the client without delivering the message.
+func (s *Service) CheckPush(origin, traceId string) bool {
+	if !s.checker.IsBlocked(origin) {
+		return false
+	}
+	BlockedPushesMetric.Inc()
+	logrus.WithFields(logrus.Fields{"origin": origin, "trace_id": traceId}).
+		Info("message silently dropped by antiscam filter")
+	return true
+}
+
+// CheckSSE returns true if the origin is blocked.
+// When true the caller should invoke WritePoisonStream instead of creating a real session.
+func (s *Service) CheckSSE(origin, traceId string) bool {
+	if !s.checker.IsBlocked(origin) {
+		return false
+	}
+	PoisonedConnectionsMetric.Inc()
+	logrus.WithFields(logrus.Fields{"origin": origin, "trace_id": traceId}).
+		Info("SSE connection poisoned by antiscam filter")
+	return true
+}
+
+// WritePoisonStream sends random hex-encoded garbage as SSE events at random
+// 2–15 s intervals until the done channel is closed or the writer fails.
+// It uses the raw http.ResponseWriter + http.Flusher so it does not depend on
+// any particular web framework.
+func (s *Service) WritePoisonStream(w http.ResponseWriter, flusher http.Flusher, done <-chan struct{}) {
+	for {
+		delay := randIntRange(2, 15)
+		select {
+		case <-done:
+			return
+		case <-time.After(time.Duration(delay) * time.Second):
+			garbage := make([]byte, 32)
+			_, _ = io.ReadFull(rand.Reader, garbage)
+			data := hex.EncodeToString(garbage)
+			_, err := fmt.Fprintf(w, "event: message\ndata: %s\n\n", data)
+			if err != nil {
+				return
+			}
+			flusher.Flush()
+		}
+	}
+}
+
+func randIntRange(min, max int) int {
+	n, _ := rand.Int(rand.Reader, big.NewInt(int64(max-min+1)))
+	return int(n.Int64()) + min
+}

--- a/internal/antiscam/service.go
+++ b/internal/antiscam/service.go
@@ -1,14 +1,6 @@
 package antiscam
 
 import (
-	"crypto/rand"
-	"encoding/hex"
-	"fmt"
-	"io"
-	"math/big"
-	"net/http"
-	"time"
-
 	"github.com/sirupsen/logrus"
 )
 
@@ -35,41 +27,13 @@ func (s *Service) CheckPush(origin, traceId string) bool {
 }
 
 // CheckSSE returns true if the origin is blocked.
-// When true the caller should invoke WritePoisonStream instead of creating a real session.
+// When true the caller should reject the request and close the connection.
 func (s *Service) CheckSSE(origin, traceId string) bool {
 	if !s.checker.IsBlocked(origin) {
 		return false
 	}
-	PoisonedConnectionsMetric.Inc()
+	BlockedConnectionsMetric.Inc()
 	logrus.WithFields(logrus.Fields{"origin": origin, "trace_id": traceId}).
-		Info("SSE connection poisoned by antiscam filter")
+		Info("SSE connection rejected by antiscam filter")
 	return true
-}
-
-// WritePoisonStream sends random hex-encoded garbage as SSE events at random
-// 2–15 s intervals until the done channel is closed or the writer fails.
-// It uses the raw http.ResponseWriter + http.Flusher so it does not depend on
-// any particular web framework.
-func (s *Service) WritePoisonStream(w http.ResponseWriter, flusher http.Flusher, done <-chan struct{}) {
-	for {
-		delay := randIntRange(2, 15)
-		select {
-		case <-done:
-			return
-		case <-time.After(time.Duration(delay) * time.Second):
-			garbage := make([]byte, randIntRange(32, 512))
-			_, _ = io.ReadFull(rand.Reader, garbage)
-			data := hex.EncodeToString(garbage)
-			_, err := fmt.Fprintf(w, "event: message\ndata: %s\n\n", data)
-			if err != nil {
-				return
-			}
-			flusher.Flush()
-		}
-	}
-}
-
-func randIntRange(min, max int) int {
-	n, _ := rand.Int(rand.Reader, big.NewInt(int64(max-min+1)))
-	return int(n.Int64()) + min
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -41,6 +41,11 @@ var Config = struct {
 	TrustedProxyRanges []string `env:"TRUSTED_PROXY_RANGES" envDefault:"0.0.0.0/0"`
 	SelfSignedTLS      bool     `env:"SELF_SIGNED_TLS" envDefault:"false"`
 
+	// Antiscam
+	AntiscamEnabled          bool   `env:"ANTISCAM_ENABLED" envDefault:"false"`
+	BlackListedDomainsURL    string `env:"BLACK_LISTED_DOMAINS_URL"`
+	BlackListRefreshInterval int    `env:"BLACK_LIST_REFRESH_INTERVAL" envDefault:"600"`
+
 	// Caching
 	ConnectCacheSize      int  `env:"CONNECT_CACHE_SIZE" envDefault:"2000000"`
 	ConnectCacheTTL       int  `env:"CONNECT_CACHE_TTL" envDefault:"300"`

--- a/internal/v3/handler/handler.go
+++ b/internal/v3/handler/handler.go
@@ -21,6 +21,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/sirupsen/logrus"
 	"github.com/ton-connect/bridge/internal/analytics"
+	"github.com/ton-connect/bridge/internal/antiscam"
 	"github.com/ton-connect/bridge/internal/config"
 	handler_common "github.com/ton-connect/bridge/internal/handler"
 	"github.com/ton-connect/bridge/internal/models"
@@ -74,9 +75,10 @@ type handler struct {
 	realIP            *utils.RealIPExtractor
 	eventCollector    analytics.EventCollector
 	eventBuilder      analytics.EventBuilder
+	antiscamService   *antiscam.Service
 }
 
-func NewHandler(s storagev3.Storage, heartbeatInterval time.Duration, extractor *utils.RealIPExtractor, timeProvider ntp.TimeProvider, collector analytics.EventCollector, builder analytics.EventBuilder) *handler {
+func NewHandler(s storagev3.Storage, heartbeatInterval time.Duration, extractor *utils.RealIPExtractor, timeProvider ntp.TimeProvider, collector analytics.EventCollector, builder analytics.EventBuilder, antiscamService *antiscam.Service) *handler {
 	// TODO support extractor in v3
 	h := handler{
 		Mux:               sync.RWMutex{},
@@ -87,6 +89,7 @@ func NewHandler(s storagev3.Storage, heartbeatInterval time.Duration, extractor 
 		heartbeatInterval: heartbeatInterval,
 		eventCollector:    collector,
 		eventBuilder:      builder,
+		antiscamService:   antiscamService,
 	}
 	return &h
 }
@@ -176,6 +179,12 @@ func (h *handler) EventRegistrationHandler(c echo.Context) error {
 		}
 	}
 	clientIdsPerConnectionMetric.Observe(float64(len(clientIds)))
+
+	origin := c.Request().Header.Get("Origin")
+	if h.antiscamService.CheckSSE(origin, traceId) {
+		h.antiscamService.WritePoisonStream(c.Response().Writer, c.Response(), c.Request().Context().Done())
+		return nil
+	}
 
 	session := h.CreateSession(clientIds, lastEventId, traceId)
 
@@ -339,6 +348,11 @@ func (h *handler) SendMessageHandler(c echo.Context) error {
 		badRequestMetric.Inc()
 		log.Error(err)
 		return h.failValidation(c, err.Error(), clientID.String(), traceId, "", "")
+	}
+
+	origin := c.Request().Header.Get("Origin")
+	if h.antiscamService.CheckPush(origin, traceId) {
+		return c.JSON(http.StatusOK, utils.HttpResOk())
 	}
 
 	if config.Config.CopyToURL != "" {

--- a/internal/v3/handler/handler.go
+++ b/internal/v3/handler/handler.go
@@ -101,6 +101,20 @@ func (h *handler) EventRegistrationHandler(c echo.Context) error {
 		http.Error(c.Response().Writer, "streaming unsupported", http.StatusInternalServerError)
 		return c.JSON(utils.HttpResError("streaming unsupported", http.StatusBadRequest))
 	}
+	params := c.QueryParams()
+
+	traceIdParam, ok := params["trace_id"]
+	traceIdValue := ""
+	if ok && len(traceIdParam) > 0 {
+		traceIdValue = traceIdParam[0]
+	}
+	traceId := handler_common.ParseOrGenerateTraceID(traceIdValue, ok && len(traceIdParam) > 0)
+
+	origin := c.Request().Header.Get("Origin")
+	if h.antiscamService.CheckSSE(origin, traceId) {
+		return c.NoContent(http.StatusForbidden)
+	}
+
 	c.Response().Header().Set("Content-Type", "text/event-stream")
 	c.Response().Header().Set("Cache-Control", "private, no-cache, no-transform")
 	c.Response().Header().Set("Connection", "keep-alive")
@@ -112,14 +126,6 @@ func (h *handler) EventRegistrationHandler(c echo.Context) error {
 		return err
 	}
 	c.Response().Flush()
-	params := c.QueryParams()
-
-	traceIdParam, ok := params["trace_id"]
-	traceIdValue := ""
-	if ok && len(traceIdParam) > 0 {
-		traceIdValue = traceIdParam[0]
-	}
-	traceId := handler_common.ParseOrGenerateTraceID(traceIdValue, ok && len(traceIdParam) > 0)
 
 	heartbeatType := "legacy"
 	if heartbeatParam, exists := params["heartbeat"]; exists && len(heartbeatParam) > 0 {
@@ -179,12 +185,6 @@ func (h *handler) EventRegistrationHandler(c echo.Context) error {
 		}
 	}
 	clientIdsPerConnectionMetric.Observe(float64(len(clientIds)))
-
-	origin := c.Request().Header.Get("Origin")
-	if h.antiscamService.CheckSSE(origin, traceId) {
-		h.antiscamService.WritePoisonStream(c.Response().Writer, c.Response(), c.Request().Context().Done())
-		return nil
-	}
 
 	session := h.CreateSession(clientIds, lastEventId, traceId)
 

--- a/internal/v3/handler/handler_test.go
+++ b/internal/v3/handler/handler_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/labstack/echo/v4"
+	"github.com/ton-connect/bridge/internal/antiscam"
 	"github.com/ton-connect/bridge/internal/ntp"
 	"github.com/ton-connect/bridge/internal/utils"
 	storagev3 "github.com/ton-connect/bridge/internal/v3/storage"
@@ -166,7 +167,7 @@ func TestHandler(t *testing.T) {
 				t.Fatalf("failed to create RealIPExtractor: %v", err)
 			}
 
-			h := NewHandler(memStorage, 10*time.Second, extractor, ntp.NewLocalTimeProvider(), nil, nil)
+			h := NewHandler(memStorage, 10*time.Second, extractor, ntp.NewLocalTimeProvider(), nil, nil, antiscam.NewService(&antiscam.NoopChecker{}))
 
 			rec := httptest.NewRecorder()
 			c := e.NewContext(req, rec)


### PR DESCRIPTION

### Summary

  Add antiscam domain filtering to the bridge to protect users from known malicious dApps.

  When enabled, the bridge checks the Origin header of incoming requests against a periodically refreshed blocklist of scam domains. Blocked origins are handled silently to avoid tipping off attackers:

  - SSE connections (/bridge/events): instead of rejecting, the bridge feeds a poison stream of random garbage data, wasting the scam dApp's resources
  - Message pushes (/bridge/message): returns 200 OK without actually delivering the message

### Why

  Scam dApps abuse the bridge to send phishing transaction requests to wallets. Blocking at the bridge level stops these messages before they reach users, without requiring wallet-side changes.