### PR TITLE
[TON-365] Connection force disconnect

### DIFF
--- a/docker/Dockerfile.gointegration
+++ b/docker/Dockerfile.gointegration
@@ -19,6 +19,8 @@ WORKDIR /app
 # COPY test/ ./test/
 
 COPY Makefile go.mod go.sum .
+COPY internal/ ./internal/
+COPY tonmetrics/ ./tonmetrics/
 COPY test/ ./test/
 
 # Default command - run the Makefile integration target which runs go tests

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -120,9 +120,6 @@ NTP_SERVERS=time.google.com,time.cloudflare.com,pool.ntp.org
 NTP_SYNC_INTERVAL=300
 SSE_MAX_LIFETIME=7200
 SSE_MAX_LIFETIME_JITTER=900
-ANTISCAM_ENABLED=true
-BLACK_LISTED_DOMAINS_URL="https://your-blocklist-source.example.com/domains.txt"
-BLACK_LIST_REFRESH_INTERVAL=600
 ```
 
 ## Using Environment Files

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -36,6 +36,19 @@ Complete reference for all environment variables supported by TON Connect Bridge
 | `TRUSTED_PROXY_RANGES` | string | `0.0.0.0/0` | Trusted proxy CIDRs for `X-Forwarded-For` (comma-separated)<br>Example: `10.0.0.0/8,172.16.0.0/12,192.168.0.0/16` |
 | `SELF_SIGNED_TLS` | bool | `false` | ⚠️ **Dev only**: Self-signed TLS cert. Use nginx/Cloudflare in prod |
 
+## SSE Connection Lifetime
+
+Long-lived SSE connections can cause load balancing instability — once a client connects, it stays pinned to a single backend indefinitely. To address this, the bridge forcefully closes SSE connections after a configurable maximum lifetime, prompting clients to reconnect (and potentially land on a different backend).
+
+A random jitter is added to each connection's lifetime to prevent all connections from closing simultaneously.
+
+| Variable | Type | Default | Description |
+|----------|------|---------|-------------|
+| `SSE_MAX_LIFETIME` | int | `7200` | Maximum SSE connection lifetime (seconds). Default: 2 hours |
+| `SSE_MAX_LIFETIME_JITTER` | int | `900` | Random jitter added to each connection's lifetime (seconds). Default: up to 15 minutes |
+
+Each connection gets its own random lifetime of `SSE_MAX_LIFETIME + rand(0..SSE_MAX_LIFETIME_JITTER)` seconds. Clients using the standard `EventSource` API will automatically reconnect with `Last-Event-ID`, so no messages are lost.
+
 ## Caching
 
 | Variable | Type | Default | Description |
@@ -105,6 +118,11 @@ BRIDGE_URL="https://use-your-own-bridge.myapp.com"
 NTP_ENABLED=true
 NTP_SERVERS=time.google.com,time.cloudflare.com,pool.ntp.org
 NTP_SYNC_INTERVAL=300
+SSE_MAX_LIFETIME=7200
+SSE_MAX_LIFETIME_JITTER=900
+ANTISCAM_ENABLED=true
+BLACK_LISTED_DOMAINS_URL="https://your-blocklist-source.example.com/domains.txt"
+BLACK_LIST_REFRESH_INTERVAL=600
 ```
 
 ## Using Environment Files

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -34,8 +34,8 @@ var Config = struct {
 	RPSLimit              int      `env:"RPS_LIMIT" envDefault:"10"`
 	ConnectionsLimit      int      `env:"CONNECTIONS_LIMIT" envDefault:"50"`
 	MaxBodySize           int64    `env:"MAX_BODY_SIZE" envDefault:"10485760"`      // 10 MB
-	SSEMaxLifetime        int      `env:"SSE_MAX_LIFETIME" envDefault:"7200"`       // 2 hours in seconds
-	SSEMaxLifetimeJitter  int      `env:"SSE_MAX_LIFETIME_JITTER" envDefault:"900"` // up to 15 min in seconds
+	SSEMaxLifetime        int64    `env:"SSE_MAX_LIFETIME" envDefault:"7200"`       // 2 hours in seconds
+	SSEMaxLifetimeJitter  int64    `env:"SSE_MAX_LIFETIME_JITTER" envDefault:"900"` // up to 15 min in seconds
 	RateLimitsByPassToken []string `env:"RATE_LIMITS_BY_PASS_TOKEN"`
 
 	// Security

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -30,13 +30,13 @@ var Config = struct {
 	PostgresLazyConnect           bool   `env:"POSTGRES_LAZY_CONNECT" envDefault:"false"`
 
 	// Performance & Limits
-	HeartbeatInterval      int      `env:"HEARTBEAT_INTERVAL" envDefault:"10"`
-	RPSLimit               int      `env:"RPS_LIMIT" envDefault:"10"`
-	ConnectionsLimit       int      `env:"CONNECTIONS_LIMIT" envDefault:"50"`
-	MaxBodySize            int64    `env:"MAX_BODY_SIZE" envDefault:"10485760"` // 10 MB
-	SSEMaxLifetime         int      `env:"SSE_MAX_LIFETIME" envDefault:"7200"`  // 2 hours in seconds
-	SSEMaxLifetimeJitter   int      `env:"SSE_MAX_LIFETIME_JITTER" envDefault:"900"` // up to 15 min in seconds
-	RateLimitsByPassToken  []string `env:"RATE_LIMITS_BY_PASS_TOKEN"`
+	HeartbeatInterval     int      `env:"HEARTBEAT_INTERVAL" envDefault:"10"`
+	RPSLimit              int      `env:"RPS_LIMIT" envDefault:"10"`
+	ConnectionsLimit      int      `env:"CONNECTIONS_LIMIT" envDefault:"50"`
+	MaxBodySize           int64    `env:"MAX_BODY_SIZE" envDefault:"10485760"`      // 10 MB
+	SSEMaxLifetime        int      `env:"SSE_MAX_LIFETIME" envDefault:"7200"`       // 2 hours in seconds
+	SSEMaxLifetimeJitter  int      `env:"SSE_MAX_LIFETIME_JITTER" envDefault:"900"` // up to 15 min in seconds
+	RateLimitsByPassToken []string `env:"RATE_LIMITS_BY_PASS_TOKEN"`
 
 	// Security
 	CorsEnable         bool     `env:"CORS_ENABLE" envDefault:"true"`

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -30,11 +30,13 @@ var Config = struct {
 	PostgresLazyConnect           bool   `env:"POSTGRES_LAZY_CONNECT" envDefault:"false"`
 
 	// Performance & Limits
-	HeartbeatInterval     int      `env:"HEARTBEAT_INTERVAL" envDefault:"10"`
-	RPSLimit              int      `env:"RPS_LIMIT" envDefault:"10"`
-	ConnectionsLimit      int      `env:"CONNECTIONS_LIMIT" envDefault:"50"`
-	MaxBodySize           int64    `env:"MAX_BODY_SIZE" envDefault:"10485760"` // 10 MB
-	RateLimitsByPassToken []string `env:"RATE_LIMITS_BY_PASS_TOKEN"`
+	HeartbeatInterval      int      `env:"HEARTBEAT_INTERVAL" envDefault:"10"`
+	RPSLimit               int      `env:"RPS_LIMIT" envDefault:"10"`
+	ConnectionsLimit       int      `env:"CONNECTIONS_LIMIT" envDefault:"50"`
+	MaxBodySize            int64    `env:"MAX_BODY_SIZE" envDefault:"10485760"` // 10 MB
+	SSEMaxLifetime         int      `env:"SSE_MAX_LIFETIME" envDefault:"7200"`  // 2 hours in seconds
+	SSEMaxLifetimeJitter   int      `env:"SSE_MAX_LIFETIME_JITTER" envDefault:"900"` // up to 15 min in seconds
+	RateLimitsByPassToken  []string `env:"RATE_LIMITS_BY_PASS_TOKEN"`
 
 	// Security
 	CorsEnable         bool     `env:"CORS_ENABLE" envDefault:"true"`

--- a/internal/v3/handler/handler.go
+++ b/internal/v3/handler/handler.go
@@ -3,13 +3,12 @@ package handlerv3
 import (
 	"bytes"
 	"context"
-	"crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
-	"math/big"
+	"math/rand"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -631,6 +630,6 @@ func sseMaxLifetimeWithJitter() time.Duration {
 	if jitterMax <= 0 {
 		return base
 	}
-	n, _ := rand.Int(rand.Reader, big.NewInt(int64(jitterMax)))
-	return base + time.Duration(n.Int64())*time.Second
+	jitterSeconds := rand.Int63n(jitterMax)
+	return base + time.Duration(jitterSeconds)*time.Second
 }

--- a/internal/v3/handler/handler.go
+++ b/internal/v3/handler/handler.go
@@ -3,17 +3,18 @@ package handlerv3
 import (
 	"bytes"
 	"context"
+	"crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
+	"math/big"
 	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
 	"sync"
-
 	"time"
 
 	"github.com/labstack/echo/v4"
@@ -206,8 +207,19 @@ func (h *handler) EventRegistrationHandler(c echo.Context) error {
 		h.removeConnection(session, traceId)
 		log.Infof("connection: %v closed with error %v", session.ClientIds, ctx.Err())
 	}()
+
+	// Force-close the session after max lifetime. This runs outside the select loop
+	// so it works even when messages are flowing continuously.
+	maxLifetime := sseMaxLifetimeWithJitter()
+	lifetimeTimer := time.AfterFunc(maxLifetime, func() {
+		log.Infof("SSE connection max lifetime reached (%v), closing", maxLifetime)
+		session.Close()
+	})
+	defer lifetimeTimer.Stop()
+
 	ticker := time.NewTicker(h.heartbeatInterval)
 	defer ticker.Stop()
+
 	session.Start()
 loop:
 	for {
@@ -610,4 +622,15 @@ func (h *handler) failValidation(
 		))
 	}
 	return c.JSON(utils.HttpResError(msg, http.StatusBadRequest))
+}
+
+// sseMaxLifetimeWithJitter returns the configured SSE max lifetime plus a random jitter.
+func sseMaxLifetimeWithJitter() time.Duration {
+	base := time.Duration(config.Config.SSEMaxLifetime) * time.Second
+	jitterMax := config.Config.SSEMaxLifetimeJitter
+	if jitterMax <= 0 {
+		return base
+	}
+	n, _ := rand.Int(rand.Reader, big.NewInt(int64(jitterMax)))
+	return base + time.Duration(n.Int64())*time.Second
 }

--- a/internal/v3/handler/session.go
+++ b/internal/v3/handler/session.go
@@ -16,6 +16,7 @@ type Session struct {
 	messageCh   chan models.SseMessage
 	Closer      chan interface{}
 	lastEventId int64
+	closeOnce   sync.Once
 }
 
 func NewSession(s storagev3.Storage, clientIds []string, lastEventId int64) *Session {
@@ -35,19 +36,21 @@ func (s *Session) GetMessages() <-chan models.SseMessage {
 	return s.messageCh
 }
 
-// Close stops the session and cleans up resources
+// Close stops the session and cleans up resources. Safe to call multiple times.
 func (s *Session) Close() {
-	log := log.WithField("prefix", "Session.Close")
-	s.mux.Lock()
-	defer s.mux.Unlock()
+	s.closeOnce.Do(func() {
+		log := log.WithField("prefix", "Session.Close")
+		s.mux.Lock()
+		defer s.mux.Unlock()
 
-	err := s.storage.Unsub(context.Background(), s.ClientIds, s.messageCh)
-	if err != nil {
-		log.Errorf("failed to unsubscribe from storage: %v", err)
-	}
+		err := s.storage.Unsub(context.Background(), s.ClientIds, s.messageCh)
+		if err != nil {
+			log.Errorf("failed to unsubscribe from storage: %v", err)
+		}
 
-	close(s.Closer)
-	close(s.messageCh)
+		close(s.Closer)
+		close(s.messageCh)
+	})
 }
 
 // Start begins the session by subscribing to storage

--- a/test/gointegration/bridge_sse_lifetime_test.go
+++ b/test/gointegration/bridge_sse_lifetime_test.go
@@ -18,7 +18,7 @@ import (
 // startLocalBridge starts a local bridge server with the given SSE lifetime config.
 // It reuses MemStorage and the v3 handler to create a fully functional bridge
 // that can be used with the existing BridgeGateway helpers.
-func startLocalBridge(t *testing.T, maxLifetimeSec, jitterSec int) *httptest.Server {
+func startLocalBridge(t *testing.T, maxLifetimeSec int64, jitterSec int64) *httptest.Server {
 	t.Helper()
 
 	config.Config.SSEMaxLifetime = maxLifetimeSec

--- a/test/gointegration/bridge_sse_lifetime_test.go
+++ b/test/gointegration/bridge_sse_lifetime_test.go
@@ -1,0 +1,323 @@
+package bridge_test
+
+import (
+	"context"
+	"fmt"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/labstack/echo/v4"
+	"github.com/ton-connect/bridge/internal/config"
+	"github.com/ton-connect/bridge/internal/ntp"
+	handlerv3 "github.com/ton-connect/bridge/internal/v3/handler"
+	storagev3 "github.com/ton-connect/bridge/internal/v3/storage"
+)
+
+// startLocalBridge starts a local bridge server with the given SSE lifetime config.
+// Returns the server and a cleanup function.
+func startLocalBridge(t *testing.T, maxLifetimeSec, jitterSec int) *httptest.Server {
+	t.Helper()
+
+	// Override global config for this test
+	config.Config.SSEMaxLifetime = maxLifetimeSec
+	config.Config.SSEMaxLifetimeJitter = jitterSec
+
+	storage := storagev3.NewMemStorage(nil, nil)
+	timeProvider := ntp.NewLocalTimeProvider()
+	h := handlerv3.NewHandler(storage, 10*time.Second, nil, timeProvider, nil, nil)
+
+	e := echo.New()
+	e.GET("/bridge/events", h.EventRegistrationHandler)
+	e.POST("/bridge/message", h.SendMessageHandler)
+
+	srv := httptest.NewServer(e)
+	return srv
+}
+
+func TestSSEMaxLifetime_ConnectionClosedAfterTimeout(t *testing.T) {
+	srv := startLocalBridge(t, 2, 0) // 2s lifetime, no jitter
+	defer srv.Close()
+
+	bridgeURL := srv.URL + "/bridge"
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	session := randomSessionID(t)
+	gw, err := OpenBridge(ctx, OpenOpts{
+		BridgeURL: bridgeURL,
+		SessionID: session,
+	})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer func() { _ = gw.Close() }()
+
+	if !gw.IsReady() {
+		t.Fatal("gateway not ready")
+	}
+
+	// Wait for connection to be closed by the server
+	start := time.Now()
+	_, err = gw.WaitMessage(ctx)
+	elapsed := time.Since(start)
+
+	// The connection should close after ~2 seconds (no jitter)
+	if elapsed < 1500*time.Millisecond {
+		t.Fatalf("connection closed too early: %v", elapsed)
+	}
+	if elapsed > 4*time.Second {
+		t.Fatalf("connection stayed open too long: %v", elapsed)
+	}
+
+	t.Logf("connection closed after %v (expected ~2s)", elapsed)
+}
+
+func TestSSEMaxLifetime_ConnectionClosedWithJitter(t *testing.T) {
+	srv := startLocalBridge(t, 2, 2) // 2s lifetime + up to 2s jitter = 2-4s
+	defer srv.Close()
+
+	bridgeURL := srv.URL + "/bridge"
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	// Open multiple connections and record when each closes
+	const numConns = 5
+	closeTimes := make(chan time.Duration, numConns)
+
+	for i := 0; i < numConns; i++ {
+		go func() {
+			session := randomSessionID(t)
+			gw, err := OpenBridge(ctx, OpenOpts{
+				BridgeURL: bridgeURL,
+				SessionID: session,
+			})
+			if err != nil {
+				closeTimes <- 0
+				return
+			}
+			defer func() { _ = gw.Close() }()
+
+			start := time.Now()
+			// Wait for the connection to be closed by server
+			for {
+				_, err := gw.WaitMessage(ctx)
+				if err != nil {
+					break
+				}
+			}
+			closeTimes <- time.Since(start)
+		}()
+	}
+
+	var durations []time.Duration
+	for i := 0; i < numConns; i++ {
+		d := <-closeTimes
+		if d == 0 {
+			t.Fatal("a connection failed to open")
+		}
+		durations = append(durations, d)
+	}
+
+	// All connections should close within the valid range: 2s to 4s (+tolerance)
+	for i, d := range durations {
+		if d < 1500*time.Millisecond || d > 6*time.Second {
+			t.Fatalf("connection %d closed at unexpected time: %v (expected 2-4s)", i, d)
+		}
+	}
+
+	// Check that not all connections closed at exactly the same time (jitter works)
+	allSame := true
+	for i := 1; i < len(durations); i++ {
+		diff := durations[i] - durations[0]
+		if diff < 0 {
+			diff = -diff
+		}
+		if diff > 200*time.Millisecond {
+			allSame = false
+			break
+		}
+	}
+
+	if allSame {
+		t.Log("WARNING: all connections closed at nearly the same time, jitter may not be effective")
+		t.Logf("durations: %v", durations)
+	} else {
+		t.Logf("jitter confirmed: durations spread across %v", durations)
+	}
+}
+
+func TestSSEMaxLifetime_MessagesDeliveredBeforeTimeout(t *testing.T) {
+	srv := startLocalBridge(t, 3, 0) // 3s lifetime, no jitter
+	defer srv.Close()
+
+	bridgeURL := srv.URL + "/bridge"
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	senderSession := randomSessionID(t)
+	sender, err := OpenBridge(ctx, OpenOpts{BridgeURL: bridgeURL, SessionID: senderSession})
+	if err != nil {
+		t.Fatalf("open sender: %v", err)
+	}
+	defer func() { _ = sender.Close() }()
+
+	receiverSession := randomSessionID(t)
+	receiver, err := OpenBridge(ctx, OpenOpts{BridgeURL: bridgeURL, SessionID: receiverSession})
+	if err != nil {
+		t.Fatalf("open receiver: %v", err)
+	}
+	defer func() { _ = receiver.Close() }()
+
+	if err := receiver.WaitReady(ctx); err != nil {
+		t.Fatalf("receiver not ready: %v", err)
+	}
+
+	// Send a message well before the lifetime expires
+	if err := sender.Send(ctx, []byte("before-timeout"), senderSession, receiverSession, nil); err != nil {
+		t.Fatalf("send: %v", err)
+	}
+
+	msgCtx, msgCancel := context.WithTimeout(ctx, 2*time.Second)
+	defer msgCancel()
+
+	ev, err := receiver.WaitMessage(msgCtx)
+	if err != nil {
+		t.Fatalf("expected to receive message before lifetime expires: %v", err)
+	}
+
+	if !strings.Contains(ev.Data, senderSession) {
+		t.Fatalf("unexpected message data: %s", ev.Data)
+	}
+	t.Logf("message delivered successfully before lifetime timeout")
+}
+
+func TestSSEMaxLifetime_ClosedDuringContinuousMessages(t *testing.T) {
+	srv := startLocalBridge(t, 2, 0) // 2s lifetime, no jitter
+	defer srv.Close()
+
+	bridgeURL := srv.URL + "/bridge"
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	senderSession := randomSessionID(t)
+	sender, err := OpenBridge(ctx, OpenOpts{BridgeURL: bridgeURL, SessionID: senderSession})
+	if err != nil {
+		t.Fatalf("open sender: %v", err)
+	}
+	defer func() { _ = sender.Close() }()
+
+	receiverSession := randomSessionID(t)
+	receiver, err := OpenBridge(ctx, OpenOpts{BridgeURL: bridgeURL, SessionID: receiverSession})
+	if err != nil {
+		t.Fatalf("open receiver: %v", err)
+	}
+	defer func() { _ = receiver.Close() }()
+
+	if err := receiver.WaitReady(ctx); err != nil {
+		t.Fatalf("receiver not ready: %v", err)
+	}
+
+	// Send messages continuously in a goroutine
+	stopSending := make(chan struct{})
+	go func() {
+		i := 0
+		for {
+			select {
+			case <-stopSending:
+				return
+			default:
+				_ = sender.Send(ctx, []byte(fmt.Sprintf("msg-%d", i)), senderSession, receiverSession, nil)
+				i++
+				time.Sleep(50 * time.Millisecond) // ~20 msgs/sec
+			}
+		}
+	}()
+
+	// Read messages until the connection closes
+	start := time.Now()
+	received := 0
+	for {
+		msgCtx, msgCancel := context.WithTimeout(ctx, 5*time.Second)
+		_, err := receiver.WaitMessage(msgCtx)
+		msgCancel()
+		if err != nil {
+			break
+		}
+		received++
+	}
+	elapsed := time.Since(start)
+	close(stopSending)
+
+	if elapsed < 1500*time.Millisecond {
+		t.Fatalf("connection closed too early: %v (received %d msgs)", elapsed, received)
+	}
+	if elapsed > 4*time.Second {
+		t.Fatalf("connection stayed open too long: %v (received %d msgs)", elapsed, received)
+	}
+
+	t.Logf("connection force-closed after %v despite receiving %d messages", elapsed, received)
+}
+
+func TestSSEMaxLifetime_MultipleMessagesThenClose(t *testing.T) {
+	srv := startLocalBridge(t, 3, 0) // 3s lifetime, no jitter
+	defer srv.Close()
+
+	bridgeURL := srv.URL + "/bridge"
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	senderSession := randomSessionID(t)
+	sender, err := OpenBridge(ctx, OpenOpts{BridgeURL: bridgeURL, SessionID: senderSession})
+	if err != nil {
+		t.Fatalf("open sender: %v", err)
+	}
+	defer func() { _ = sender.Close() }()
+
+	receiverSession := randomSessionID(t)
+	receiver, err := OpenBridge(ctx, OpenOpts{BridgeURL: bridgeURL, SessionID: receiverSession})
+	if err != nil {
+		t.Fatalf("open receiver: %v", err)
+	}
+	defer func() { _ = receiver.Close() }()
+
+	if err := receiver.WaitReady(ctx); err != nil {
+		t.Fatalf("receiver not ready: %v", err)
+	}
+
+	// Send 3 messages quickly
+	for i := 0; i < 3; i++ {
+		msg := fmt.Sprintf("msg-%d", i)
+		if err := sender.Send(ctx, []byte(msg), senderSession, receiverSession, nil); err != nil {
+			t.Fatalf("send %d: %v", i, err)
+		}
+	}
+
+	// Receive all 3
+	for i := 0; i < 3; i++ {
+		msgCtx, msgCancel := context.WithTimeout(ctx, 2*time.Second)
+		_, err := receiver.WaitMessage(msgCtx)
+		msgCancel()
+		if err != nil {
+			t.Fatalf("failed to receive message %d: %v", i, err)
+		}
+	}
+
+	// Now wait for the connection to be closed by the server
+	start := time.Now()
+	_, err = receiver.WaitMessage(ctx)
+	elapsed := time.Since(start)
+
+	// Should close within the remaining lifetime (~3s from start, minus time already spent)
+	if elapsed > 5*time.Second {
+		t.Fatalf("connection stayed open too long after messages: %v", elapsed)
+	}
+
+	t.Logf("connection closed %v after last message (lifetime enforced)", elapsed)
+}

--- a/test/gointegration/bridge_sse_lifetime_test.go
+++ b/test/gointegration/bridge_sse_lifetime_test.go
@@ -16,11 +16,11 @@ import (
 )
 
 // startLocalBridge starts a local bridge server with the given SSE lifetime config.
-// Returns the server and a cleanup function.
+// It reuses MemStorage and the v3 handler to create a fully functional bridge
+// that can be used with the existing BridgeGateway helpers.
 func startLocalBridge(t *testing.T, maxLifetimeSec, jitterSec int) *httptest.Server {
 	t.Helper()
 
-	// Override global config for this test
 	config.Config.SSEMaxLifetime = maxLifetimeSec
 	config.Config.SSEMaxLifetimeJitter = jitterSec
 
@@ -32,11 +32,10 @@ func startLocalBridge(t *testing.T, maxLifetimeSec, jitterSec int) *httptest.Ser
 	e.GET("/bridge/events", h.EventRegistrationHandler)
 	e.POST("/bridge/message", h.SendMessageHandler)
 
-	srv := httptest.NewServer(e)
-	return srv
+	return httptest.NewServer(e)
 }
 
-func TestSSEMaxLifetime_ConnectionClosedAfterTimeout(t *testing.T) {
+func TestBridge_SSEMaxLifetime_ConnectionClosedAfterTimeout(t *testing.T) {
 	srv := startLocalBridge(t, 2, 0) // 2s lifetime, no jitter
 	defer srv.Close()
 
@@ -59,24 +58,21 @@ func TestSSEMaxLifetime_ConnectionClosedAfterTimeout(t *testing.T) {
 		t.Fatal("gateway not ready")
 	}
 
-	// Wait for connection to be closed by the server
 	start := time.Now()
 	_, _ = gw.WaitMessage(ctx)
 	elapsed := time.Since(start)
 
-	// The connection should close after ~2 seconds (no jitter)
 	if elapsed < 1500*time.Millisecond {
 		t.Fatalf("connection closed too early: %v", elapsed)
 	}
 	if elapsed > 4*time.Second {
 		t.Fatalf("connection stayed open too long: %v", elapsed)
 	}
-
 	t.Logf("connection closed after %v (expected ~2s)", elapsed)
 }
 
-func TestSSEMaxLifetime_ConnectionClosedWithJitter(t *testing.T) {
-	srv := startLocalBridge(t, 2, 2) // 2s lifetime + up to 2s jitter = 2-4s
+func TestBridge_SSEMaxLifetime_ConnectionClosedWithJitter(t *testing.T) {
+	srv := startLocalBridge(t, 2, 2) // 2s + up to 2s jitter = 2-4s
 	defer srv.Close()
 
 	bridgeURL := srv.URL + "/bridge"
@@ -84,7 +80,6 @@ func TestSSEMaxLifetime_ConnectionClosedWithJitter(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 
-	// Open multiple connections and record when each closes
 	const numConns = 5
 	closeTimes := make(chan time.Duration, numConns)
 
@@ -102,7 +97,6 @@ func TestSSEMaxLifetime_ConnectionClosedWithJitter(t *testing.T) {
 			defer func() { _ = gw.Close() }()
 
 			start := time.Now()
-			// Wait for the connection to be closed by server
 			for {
 				_, err := gw.WaitMessage(ctx)
 				if err != nil {
@@ -122,14 +116,12 @@ func TestSSEMaxLifetime_ConnectionClosedWithJitter(t *testing.T) {
 		durations = append(durations, d)
 	}
 
-	// All connections should close within the valid range: 2s to 4s (+tolerance)
 	for i, d := range durations {
 		if d < 1500*time.Millisecond || d > 6*time.Second {
 			t.Fatalf("connection %d closed at unexpected time: %v (expected 2-4s)", i, d)
 		}
 	}
 
-	// Check that not all connections closed at exactly the same time (jitter works)
 	allSame := true
 	for i := 1; i < len(durations); i++ {
 		diff := durations[i] - durations[0]
@@ -141,17 +133,15 @@ func TestSSEMaxLifetime_ConnectionClosedWithJitter(t *testing.T) {
 			break
 		}
 	}
-
 	if allSame {
-		t.Log("WARNING: all connections closed at nearly the same time, jitter may not be effective")
-		t.Logf("durations: %v", durations)
+		t.Logf("WARNING: all connections closed at nearly the same time: %v", durations)
 	} else {
-		t.Logf("jitter confirmed: durations spread across %v", durations)
+		t.Logf("jitter confirmed: %v", durations)
 	}
 }
 
-func TestSSEMaxLifetime_MessagesDeliveredBeforeTimeout(t *testing.T) {
-	srv := startLocalBridge(t, 3, 0) // 3s lifetime, no jitter
+func TestBridge_SSEMaxLifetime_MessagesDeliveredBeforeTimeout(t *testing.T) {
+	srv := startLocalBridge(t, 3, 0)
 	defer srv.Close()
 
 	bridgeURL := srv.URL + "/bridge"
@@ -177,7 +167,6 @@ func TestSSEMaxLifetime_MessagesDeliveredBeforeTimeout(t *testing.T) {
 		t.Fatalf("receiver not ready: %v", err)
 	}
 
-	// Send a message well before the lifetime expires
 	if err := sender.Send(ctx, []byte("before-timeout"), senderSession, receiverSession, nil); err != nil {
 		t.Fatalf("send: %v", err)
 	}
@@ -187,16 +176,15 @@ func TestSSEMaxLifetime_MessagesDeliveredBeforeTimeout(t *testing.T) {
 
 	ev, err := receiver.WaitMessage(msgCtx)
 	if err != nil {
-		t.Fatalf("expected to receive message before lifetime expires: %v", err)
+		t.Fatalf("expected message before lifetime expires: %v", err)
 	}
-
 	if !strings.Contains(ev.Data, senderSession) {
 		t.Fatalf("unexpected message data: %s", ev.Data)
 	}
-	t.Logf("message delivered successfully before lifetime timeout")
+	t.Logf("message delivered before lifetime timeout")
 }
 
-func TestSSEMaxLifetime_ClosedDuringContinuousMessages(t *testing.T) {
+func TestBridge_SSEMaxLifetime_ClosedDuringContinuousMessages(t *testing.T) {
 	srv := startLocalBridge(t, 2, 0) // 2s lifetime, no jitter
 	defer srv.Close()
 
@@ -223,7 +211,7 @@ func TestSSEMaxLifetime_ClosedDuringContinuousMessages(t *testing.T) {
 		t.Fatalf("receiver not ready: %v", err)
 	}
 
-	// Send messages continuously in a goroutine
+	// Send messages continuously
 	stopSending := make(chan struct{})
 	go func() {
 		i := 0
@@ -234,12 +222,11 @@ func TestSSEMaxLifetime_ClosedDuringContinuousMessages(t *testing.T) {
 			default:
 				_ = sender.Send(ctx, []byte(fmt.Sprintf("msg-%d", i)), senderSession, receiverSession, nil)
 				i++
-				time.Sleep(50 * time.Millisecond) // ~20 msgs/sec
+				time.Sleep(50 * time.Millisecond)
 			}
 		}
 	}()
 
-	// Read messages until the connection closes
 	start := time.Now()
 	received := 0
 	for {
@@ -260,64 +247,5 @@ func TestSSEMaxLifetime_ClosedDuringContinuousMessages(t *testing.T) {
 	if elapsed > 4*time.Second {
 		t.Fatalf("connection stayed open too long: %v (received %d msgs)", elapsed, received)
 	}
-
-	t.Logf("connection force-closed after %v despite receiving %d messages", elapsed, received)
-}
-
-func TestSSEMaxLifetime_MultipleMessagesThenClose(t *testing.T) {
-	srv := startLocalBridge(t, 3, 0) // 3s lifetime, no jitter
-	defer srv.Close()
-
-	bridgeURL := srv.URL + "/bridge"
-
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-
-	senderSession := randomSessionID(t)
-	sender, err := OpenBridge(ctx, OpenOpts{BridgeURL: bridgeURL, SessionID: senderSession})
-	if err != nil {
-		t.Fatalf("open sender: %v", err)
-	}
-	defer func() { _ = sender.Close() }()
-
-	receiverSession := randomSessionID(t)
-	receiver, err := OpenBridge(ctx, OpenOpts{BridgeURL: bridgeURL, SessionID: receiverSession})
-	if err != nil {
-		t.Fatalf("open receiver: %v", err)
-	}
-	defer func() { _ = receiver.Close() }()
-
-	if err := receiver.WaitReady(ctx); err != nil {
-		t.Fatalf("receiver not ready: %v", err)
-	}
-
-	// Send 3 messages quickly
-	for i := 0; i < 3; i++ {
-		msg := fmt.Sprintf("msg-%d", i)
-		if err := sender.Send(ctx, []byte(msg), senderSession, receiverSession, nil); err != nil {
-			t.Fatalf("send %d: %v", i, err)
-		}
-	}
-
-	// Receive all 3
-	for i := 0; i < 3; i++ {
-		msgCtx, msgCancel := context.WithTimeout(ctx, 2*time.Second)
-		_, err := receiver.WaitMessage(msgCtx)
-		msgCancel()
-		if err != nil {
-			t.Fatalf("failed to receive message %d: %v", i, err)
-		}
-	}
-
-	// Now wait for the connection to be closed by the server
-	start := time.Now()
-	_, _ = receiver.WaitMessage(ctx)
-	elapsed := time.Since(start)
-
-	// Should close within the remaining lifetime (~3s from start, minus time already spent)
-	if elapsed > 5*time.Second {
-		t.Fatalf("connection stayed open too long after messages: %v", elapsed)
-	}
-
-	t.Logf("connection closed %v after last message (lifetime enforced)", elapsed)
+	t.Logf("force-closed after %v despite receiving %d messages", elapsed, received)
 }

--- a/test/gointegration/bridge_sse_lifetime_test.go
+++ b/test/gointegration/bridge_sse_lifetime_test.go
@@ -61,7 +61,7 @@ func TestSSEMaxLifetime_ConnectionClosedAfterTimeout(t *testing.T) {
 
 	// Wait for connection to be closed by the server
 	start := time.Now()
-	_, err = gw.WaitMessage(ctx)
+	_, _ = gw.WaitMessage(ctx)
 	elapsed := time.Since(start)
 
 	// The connection should close after ~2 seconds (no jitter)
@@ -311,7 +311,7 @@ func TestSSEMaxLifetime_MultipleMessagesThenClose(t *testing.T) {
 
 	// Now wait for the connection to be closed by the server
 	start := time.Now()
-	_, err = receiver.WaitMessage(ctx)
+	_, _ = receiver.WaitMessage(ctx)
 	elapsed := time.Since(start)
 
 	// Should close within the remaining lifetime (~3s from start, minus time already spent)


### PR DESCRIPTION
Force-close SSE connections after a configurable maximum lifetime to improve load balancing across bridge instances. Without this, clients stay pinned to a single backend indefinitely, causing uneven load distribution.

  - Connections are closed after `SSE_MAX_LIFETIME` (default 2h) plus a random jitter of up to `SSE_MAX_LIFETIME_JITTER` (default 15min)
  - Each connection gets its own independent jitter so they don't all drop at once
  - Clients using EventSource auto-reconnect with `Last-Event-ID`, so no messages are lost