### PR TITLE
[TON-370] By recipient rate limiting

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -21,11 +21,11 @@ This directory contains performance testing tools for the Ton Connect Bridge Ser
 
 > **Tip: Bypass Bridge Rate Limits in Local/Test**
 
-If your bridge server is configured with request rate limiting (e.g. `RPS_LIMIT`), you can bypass these limits for benchmark and development purposes by setting the environment variable `RATE_LIMITS_BY_PASS_TOKEN` to a known token, such as `test-token`.  
+If your bridge server is configured with request rate limiting (e.g. `RPS_LIMIT`), you can bypass these limits for benchmark and development purposes by setting the environment variable `RATE_LIMITS_BYPASS_TOKEN` to a known token, such as `test-token`.  
 The benchmark script will use this token via its `Authorization: Bearer` header, so you should make sure your bridge instantiation command includes this variable:
 
 ```bash
-RATE_LIMITS_BY_PASS_TOKEN=test-token \
+RATE_LIMITS_BYPASS_TOKEN=test-token \
 STORAGE=valkey VALKEY_URI=redis://127.0.0.1:6379 \
 PORT=8081 CORS_ENABLE=true RPS_LIMIT=100 CONNECTIONS_LIMIT=8000 \
 LOG_LEVEL=error ./bridge

--- a/cmd/bridge/main.go
+++ b/cmd/bridge/main.go
@@ -98,7 +98,7 @@ func main() {
 		return false
 	}))
 	recipientRateLimitInterval := time.Duration(config.Config.RecipientRateLimitInterval) * time.Second
-	e.Use(app.RecipientRateLimitMiddleware(bridge_middleware.NewRecipientRateLimiter(recipientRateLimitInterval), func(c echo.Context) bool {
+	e.Use(app.RecipientRateLimitMiddleware(bridge_middleware.NewRecipientRateLimiter(recipientRateLimitInterval, config.Config.RecipientRateLimitRPI), func(c echo.Context) bool {
 		if app.SkipRateLimitsByToken(c.Request()) || c.Path() != "/bridge/message" {
 			return true
 		}

--- a/cmd/bridge/main.go
+++ b/cmd/bridge/main.go
@@ -97,6 +97,13 @@ func main() {
 		}
 		return false
 	}))
+	recipientRateLimitInterval := time.Duration(config.Config.RecipientRateLimitInterval) * time.Second
+	e.Use(app.RecipientRateLimitMiddleware(bridge_middleware.NewRecipientRateLimiter(recipientRateLimitInterval), func(c echo.Context) bool {
+		if app.SkipRateLimitsByToken(c.Request()) || c.Path() != "/bridge/message" {
+			return true
+		}
+		return false
+	}))
 
 	if config.Config.CorsEnable {
 		corsConfig := middleware.CORSWithConfig(middleware.CORSConfig{

--- a/cmd/bridge/main.go
+++ b/cmd/bridge/main.go
@@ -98,7 +98,11 @@ func main() {
 		return false
 	}))
 	recipientRateLimitInterval := time.Duration(config.Config.RecipientRateLimitInterval) * time.Second
-	e.Use(app.RecipientRateLimitMiddleware(bridge_middleware.NewRecipientRateLimiter(recipientRateLimitInterval, config.Config.RecipientRateLimitRPI), func(c echo.Context) bool {
+	e.Use(app.RecipientRateLimitMiddleware(bridge_middleware.NewRecipientRateLimiter(
+		recipientRateLimitInterval,
+		config.Config.RecipientRateLimitRPI,
+		config.Config.RecipientRateLimitMaxSize,
+	), func(c echo.Context) bool {
 		if app.SkipRateLimitsByToken(c.Request()) || c.Path() != "/bridge/message" {
 			return true
 		}

--- a/cmd/bridge3/main.go
+++ b/cmd/bridge3/main.go
@@ -141,7 +141,11 @@ func main() {
 		return false
 	}))
 	recipientRateLimitInterval := time.Duration(config.Config.RecipientRateLimitInterval) * time.Second
-	e.Use(app.RecipientRateLimitMiddleware(bridge_middleware.NewRecipientRateLimiter(recipientRateLimitInterval, config.Config.RecipientRateLimitRPI), func(c echo.Context) bool {
+	e.Use(app.RecipientRateLimitMiddleware(bridge_middleware.NewRecipientRateLimiter(
+		recipientRateLimitInterval,
+		config.Config.RecipientRateLimitRPI,
+		config.Config.RecipientRateLimitMaxSize,
+	), func(c echo.Context) bool {
 		if app.SkipRateLimitsByToken(c.Request()) || c.Path() != "/bridge/message" {
 			return true
 		}

--- a/cmd/bridge3/main.go
+++ b/cmd/bridge3/main.go
@@ -141,7 +141,7 @@ func main() {
 		return false
 	}))
 	recipientRateLimitInterval := time.Duration(config.Config.RecipientRateLimitInterval) * time.Second
-	e.Use(app.RecipientRateLimitMiddleware(bridge_middleware.NewRecipientRateLimiter(recipientRateLimitInterval), func(c echo.Context) bool {
+	e.Use(app.RecipientRateLimitMiddleware(bridge_middleware.NewRecipientRateLimiter(recipientRateLimitInterval, config.Config.RecipientRateLimitRPI), func(c echo.Context) bool {
 		if app.SkipRateLimitsByToken(c.Request()) || c.Path() != "/bridge/message" {
 			return true
 		}

--- a/cmd/bridge3/main.go
+++ b/cmd/bridge3/main.go
@@ -140,6 +140,13 @@ func main() {
 		}
 		return false
 	}))
+	recipientRateLimitInterval := time.Duration(config.Config.RecipientRateLimitInterval) * time.Second
+	e.Use(app.RecipientRateLimitMiddleware(bridge_middleware.NewRecipientRateLimiter(recipientRateLimitInterval), func(c echo.Context) bool {
+		if app.SkipRateLimitsByToken(c.Request()) || c.Path() != "/bridge/message" {
+			return true
+		}
+		return false
+	}))
 
 	if config.Config.CorsEnable {
 		corsConfig := middleware.CORSWithConfig(middleware.CORSConfig{

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -26,6 +26,7 @@ Complete reference for all environment variables supported by TON Connect Bridge
 | `RPS_LIMIT` | int | `1` | Requests/sec per IP for `/bridge/message` |
 | `CONNECTIONS_LIMIT` | int | `50` | Max concurrent SSE connections per IP |
 | `MAX_BODY_SIZE` | int | `10485760` | Max HTTP request body size (bytes) for `/bridge/message` |
+| `RECIPIENT_RATE_LIMIT_INTERVAL` | int | `10` | Per-recipient push rate limit interval (seconds). 1 push per interval per `to` address. Set to 0 to disable |
 | `RATE_LIMITS_BY_PASS_TOKEN` | string | - | Bypass tokens (comma-separated) |
 
 ## Security

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -26,8 +26,9 @@ Complete reference for all environment variables supported by TON Connect Bridge
 | `RPS_LIMIT` | int | `1` | Requests/sec per IP for `/bridge/message` |
 | `CONNECTIONS_LIMIT` | int | `50` | Max concurrent SSE connections per IP |
 | `MAX_BODY_SIZE` | int | `10485760` | Max HTTP request body size (bytes) for `/bridge/message` |
-| `RECIPIENT_RATE_LIMIT_INTERVAL` | int | `0` | Per-recipient push rate limit interval (seconds). 1 push per interval per `to` address. 0 = disabled |
-| `RATE_LIMITS_BY_PASS_TOKEN` | string | - | Bypass tokens (comma-separated) |
+| `RECIPIENT_RATE_LIMIT_INTERVAL` | int | `0` | Per-recipient push rate limit interval (seconds). 0 = disabled |
+| `RECIPIENT_RATE_LIMIT_RPI` | int | `1` | Requests per interval allowed per recipient |
+| `RATE_LIMITS_BYPASS_TOKEN` | string | - | Bypass tokens (comma-separated) |
 
 ## Security
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -28,6 +28,7 @@ Complete reference for all environment variables supported by TON Connect Bridge
 | `MAX_BODY_SIZE` | int | `10485760` | Max HTTP request body size (bytes) for `/bridge/message` |
 | `RECIPIENT_RATE_LIMIT_INTERVAL` | int | `0` | Per-recipient push rate limit interval (seconds). 0 = disabled |
 | `RECIPIENT_RATE_LIMIT_RPI` | int | `1` | Requests per interval allowed per recipient |
+| `RECIPIENT_RATE_LIMIT_MAX_SIZE` | int | `10000` | Max tracked recipients for rate limiting (LRU eviction). 0 = unlimited |
 | `RATE_LIMITS_BYPASS_TOKEN` | string | - | Bypass tokens (comma-separated) |
 
 ## Security

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -26,7 +26,7 @@ Complete reference for all environment variables supported by TON Connect Bridge
 | `RPS_LIMIT` | int | `1` | Requests/sec per IP for `/bridge/message` |
 | `CONNECTIONS_LIMIT` | int | `50` | Max concurrent SSE connections per IP |
 | `MAX_BODY_SIZE` | int | `10485760` | Max HTTP request body size (bytes) for `/bridge/message` |
-| `RECIPIENT_RATE_LIMIT_INTERVAL` | int | `10` | Per-recipient push rate limit interval (seconds). 1 push per interval per `to` address. Set to 0 to disable |
+| `RECIPIENT_RATE_LIMIT_INTERVAL` | int | `0` | Per-recipient push rate limit interval (seconds). 1 push per interval per `to` address. 0 = disabled |
 | `RATE_LIMITS_BY_PASS_TOKEN` | string | - | Bypass tokens (comma-separated) |
 
 ## Security

--- a/docs/MONITORING.md
+++ b/docs/MONITORING.md
@@ -152,7 +152,7 @@ rate(http_requests_total[5m]) * 100
 #### `bridge_token_usage`
 **Type:** Counter  
 **Labels:** `token`  
-**Description:** Usage count per bypass token (from `RATE_LIMITS_BY_PASS_TOKEN`).
+**Description:** Usage count per bypass token (from `RATE_LIMITS_BYPASS_TOKEN`).
 
 **Usage:**
 ```promql

--- a/internal/app/middleware.go
+++ b/internal/app/middleware.go
@@ -29,6 +29,24 @@ func SkipRateLimitsByToken(request *http.Request) bool {
 	return false
 }
 
+// RecipientRateLimitMiddleware creates middleware for per-recipient rate limiting
+func RecipientRateLimitMiddleware(limiter *bridge_middleware.RecipientRateLimiter, skipper func(c echo.Context) bool) echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			if skipper(c) {
+				return next(c)
+			}
+			to := c.QueryParam("to")
+			if to != "" && !limiter.Allow(to) {
+				return c.JSON(http.StatusTooManyRequests, map[string]string{
+					"error": "too many requests to this recipient",
+				})
+			}
+			return next(c)
+		}
+	}
+}
+
 // ConnectionsLimitMiddleware creates middleware for limiting concurrent connections
 func ConnectionsLimitMiddleware(counter *bridge_middleware.ConnectionsLimiter, skipper func(c echo.Context) bool) echo.MiddlewareFunc {
 	return func(next echo.HandlerFunc) echo.HandlerFunc {

--- a/internal/app/middleware.go
+++ b/internal/app/middleware.go
@@ -21,7 +21,7 @@ func SkipRateLimitsByToken(request *http.Request) bool {
 		return false
 	}
 	token := strings.TrimPrefix(authorization, "Bearer ")
-	exist := slices.Contains(config.Config.RateLimitsByPassToken, token)
+	exist := slices.Contains(config.Config.RateLimitsBypassToken, token)
 	if exist {
 		TokenUsageMetric.WithLabelValues(token).Inc()
 		return true

--- a/internal/app/middleware_test.go
+++ b/internal/app/middleware_test.go
@@ -1,0 +1,142 @@
+package app
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/labstack/echo/v4"
+	bridge_middleware "github.com/ton-connect/bridge/internal/middleware"
+)
+
+func TestRecipientRateLimitMiddleware_AllowsFirstRequest(t *testing.T) {
+	e := echo.New()
+	limiter := bridge_middleware.NewRecipientRateLimiter(time.Second)
+	defer limiter.Stop()
+
+	mw := RecipientRateLimitMiddleware(limiter, func(c echo.Context) bool { return false })
+	handler := mw(func(c echo.Context) error {
+		return c.String(http.StatusOK, "ok")
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/bridge/message?to=abc123", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	if err := handler(c); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", rec.Code)
+	}
+}
+
+func TestRecipientRateLimitMiddleware_BlocksSecondRequest(t *testing.T) {
+	e := echo.New()
+	limiter := bridge_middleware.NewRecipientRateLimiter(time.Second)
+	defer limiter.Stop()
+
+	mw := RecipientRateLimitMiddleware(limiter, func(c echo.Context) bool { return false })
+	handler := mw(func(c echo.Context) error {
+		return c.String(http.StatusOK, "ok")
+	})
+
+	// First request — allowed
+	req := httptest.NewRequest(http.MethodPost, "/bridge/message?to=abc123", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	if err := handler(c); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Second request — blocked
+	req = httptest.NewRequest(http.MethodPost, "/bridge/message?to=abc123", nil)
+	rec = httptest.NewRecorder()
+	c = e.NewContext(req, rec)
+	if err := handler(c); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rec.Code != http.StatusTooManyRequests {
+		t.Fatalf("expected status 429, got %d", rec.Code)
+	}
+
+	var body map[string]string
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("failed to parse response body: %v", err)
+	}
+	if body["error"] != "too many requests to this recipient" {
+		t.Fatalf("unexpected error message: %s", body["error"])
+	}
+}
+
+func TestRecipientRateLimitMiddleware_SkipperBypasses(t *testing.T) {
+	e := echo.New()
+	limiter := bridge_middleware.NewRecipientRateLimiter(time.Second)
+	defer limiter.Stop()
+
+	mw := RecipientRateLimitMiddleware(limiter, func(c echo.Context) bool { return true })
+	handler := mw(func(c echo.Context) error {
+		return c.String(http.StatusOK, "ok")
+	})
+
+	for i := 0; i < 5; i++ {
+		req := httptest.NewRequest(http.MethodPost, "/bridge/message?to=abc123", nil)
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
+		if err := handler(c); err != nil {
+			t.Fatalf("unexpected error on request %d: %v", i, err)
+		}
+		if rec.Code != http.StatusOK {
+			t.Fatalf("expected status 200 with skipper, got %d on request %d", rec.Code, i)
+		}
+	}
+}
+
+func TestRecipientRateLimitMiddleware_NoToParam(t *testing.T) {
+	e := echo.New()
+	limiter := bridge_middleware.NewRecipientRateLimiter(time.Second)
+	defer limiter.Stop()
+
+	mw := RecipientRateLimitMiddleware(limiter, func(c echo.Context) bool { return false })
+	handler := mw(func(c echo.Context) error {
+		return c.String(http.StatusOK, "ok")
+	})
+
+	for i := 0; i < 5; i++ {
+		req := httptest.NewRequest(http.MethodPost, "/bridge/message", nil)
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
+		if err := handler(c); err != nil {
+			t.Fatalf("unexpected error on request %d: %v", i, err)
+		}
+		if rec.Code != http.StatusOK {
+			t.Fatalf("expected status 200 without to param, got %d on request %d", rec.Code, i)
+		}
+	}
+}
+
+func TestRecipientRateLimitMiddleware_DifferentRecipients(t *testing.T) {
+	e := echo.New()
+	limiter := bridge_middleware.NewRecipientRateLimiter(time.Second)
+	defer limiter.Stop()
+
+	mw := RecipientRateLimitMiddleware(limiter, func(c echo.Context) bool { return false })
+	handler := mw(func(c echo.Context) error {
+		return c.String(http.StatusOK, "ok")
+	})
+
+	recipients := []string{"aaa", "bbb", "ccc"}
+	for _, to := range recipients {
+		req := httptest.NewRequest(http.MethodPost, "/bridge/message?to="+to, nil)
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
+		if err := handler(c); err != nil {
+			t.Fatalf("unexpected error for recipient %s: %v", to, err)
+		}
+		if rec.Code != http.StatusOK {
+			t.Fatalf("expected status 200 for first request to %s, got %d", to, rec.Code)
+		}
+	}
+}

--- a/internal/app/middleware_test.go
+++ b/internal/app/middleware_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestRecipientRateLimitMiddleware_AllowsFirstRequest(t *testing.T) {
 	e := echo.New()
-	limiter := bridge_middleware.NewRecipientRateLimiter(time.Second)
+	limiter := bridge_middleware.NewRecipientRateLimiter(time.Second, 1)
 	defer limiter.Stop()
 
 	mw := RecipientRateLimitMiddleware(limiter, func(c echo.Context) bool { return false })
@@ -35,7 +35,7 @@ func TestRecipientRateLimitMiddleware_AllowsFirstRequest(t *testing.T) {
 
 func TestRecipientRateLimitMiddleware_BlocksSecondRequest(t *testing.T) {
 	e := echo.New()
-	limiter := bridge_middleware.NewRecipientRateLimiter(time.Second)
+	limiter := bridge_middleware.NewRecipientRateLimiter(time.Second, 1)
 	defer limiter.Stop()
 
 	mw := RecipientRateLimitMiddleware(limiter, func(c echo.Context) bool { return false })
@@ -73,7 +73,7 @@ func TestRecipientRateLimitMiddleware_BlocksSecondRequest(t *testing.T) {
 
 func TestRecipientRateLimitMiddleware_SkipperBypasses(t *testing.T) {
 	e := echo.New()
-	limiter := bridge_middleware.NewRecipientRateLimiter(time.Second)
+	limiter := bridge_middleware.NewRecipientRateLimiter(time.Second, 1)
 	defer limiter.Stop()
 
 	mw := RecipientRateLimitMiddleware(limiter, func(c echo.Context) bool { return true })
@@ -96,7 +96,7 @@ func TestRecipientRateLimitMiddleware_SkipperBypasses(t *testing.T) {
 
 func TestRecipientRateLimitMiddleware_NoToParam(t *testing.T) {
 	e := echo.New()
-	limiter := bridge_middleware.NewRecipientRateLimiter(time.Second)
+	limiter := bridge_middleware.NewRecipientRateLimiter(time.Second, 1)
 	defer limiter.Stop()
 
 	mw := RecipientRateLimitMiddleware(limiter, func(c echo.Context) bool { return false })
@@ -119,7 +119,7 @@ func TestRecipientRateLimitMiddleware_NoToParam(t *testing.T) {
 
 func TestRecipientRateLimitMiddleware_DifferentRecipients(t *testing.T) {
 	e := echo.New()
-	limiter := bridge_middleware.NewRecipientRateLimiter(time.Second)
+	limiter := bridge_middleware.NewRecipientRateLimiter(time.Second, 1)
 	defer limiter.Stop()
 
 	mw := RecipientRateLimitMiddleware(limiter, func(c echo.Context) bool { return false })

--- a/internal/app/middleware_test.go
+++ b/internal/app/middleware_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestRecipientRateLimitMiddleware_AllowsFirstRequest(t *testing.T) {
 	e := echo.New()
-	limiter := bridge_middleware.NewRecipientRateLimiter(time.Second, 1)
+	limiter := bridge_middleware.NewRecipientRateLimiter(time.Second, 1, 0)
 	defer limiter.Stop()
 
 	mw := RecipientRateLimitMiddleware(limiter, func(c echo.Context) bool { return false })
@@ -35,7 +35,7 @@ func TestRecipientRateLimitMiddleware_AllowsFirstRequest(t *testing.T) {
 
 func TestRecipientRateLimitMiddleware_BlocksSecondRequest(t *testing.T) {
 	e := echo.New()
-	limiter := bridge_middleware.NewRecipientRateLimiter(time.Second, 1)
+	limiter := bridge_middleware.NewRecipientRateLimiter(time.Second, 1, 0)
 	defer limiter.Stop()
 
 	mw := RecipientRateLimitMiddleware(limiter, func(c echo.Context) bool { return false })
@@ -73,7 +73,7 @@ func TestRecipientRateLimitMiddleware_BlocksSecondRequest(t *testing.T) {
 
 func TestRecipientRateLimitMiddleware_SkipperBypasses(t *testing.T) {
 	e := echo.New()
-	limiter := bridge_middleware.NewRecipientRateLimiter(time.Second, 1)
+	limiter := bridge_middleware.NewRecipientRateLimiter(time.Second, 1, 0)
 	defer limiter.Stop()
 
 	mw := RecipientRateLimitMiddleware(limiter, func(c echo.Context) bool { return true })
@@ -96,7 +96,7 @@ func TestRecipientRateLimitMiddleware_SkipperBypasses(t *testing.T) {
 
 func TestRecipientRateLimitMiddleware_NoToParam(t *testing.T) {
 	e := echo.New()
-	limiter := bridge_middleware.NewRecipientRateLimiter(time.Second, 1)
+	limiter := bridge_middleware.NewRecipientRateLimiter(time.Second, 1, 0)
 	defer limiter.Stop()
 
 	mw := RecipientRateLimitMiddleware(limiter, func(c echo.Context) bool { return false })
@@ -119,7 +119,7 @@ func TestRecipientRateLimitMiddleware_NoToParam(t *testing.T) {
 
 func TestRecipientRateLimitMiddleware_DifferentRecipients(t *testing.T) {
 	e := echo.New()
-	limiter := bridge_middleware.NewRecipientRateLimiter(time.Second, 1)
+	limiter := bridge_middleware.NewRecipientRateLimiter(time.Second, 1, 0)
 	defer limiter.Stop()
 
 	mw := RecipientRateLimitMiddleware(limiter, func(c echo.Context) bool { return false })

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -30,10 +30,10 @@ var Config = struct {
 	PostgresLazyConnect           bool   `env:"POSTGRES_LAZY_CONNECT" envDefault:"false"`
 
 	// Performance & Limits
-	HeartbeatInterval            int      `env:"HEARTBEAT_INTERVAL" envDefault:"10"`
-	RPSLimit                     int      `env:"RPS_LIMIT" envDefault:"10"`
-	ConnectionsLimit             int      `env:"CONNECTIONS_LIMIT" envDefault:"50"`
-	MaxBodySize                  int64    `env:"MAX_BODY_SIZE" envDefault:"10485760"` // 10 MB
+	HeartbeatInterval          int      `env:"HEARTBEAT_INTERVAL" envDefault:"10"`
+	RPSLimit                   int      `env:"RPS_LIMIT" envDefault:"10"`
+	ConnectionsLimit           int      `env:"CONNECTIONS_LIMIT" envDefault:"50"`
+	MaxBodySize                int64    `env:"MAX_BODY_SIZE" envDefault:"10485760"` // 10 MB
 	RecipientRateLimitInterval int      `env:"RECIPIENT_RATE_LIMIT_INTERVAL" envDefault:"10"`
 	RateLimitsByPassToken      []string `env:"RATE_LIMITS_BY_PASS_TOKEN"`
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -35,7 +35,8 @@ var Config = struct {
 	ConnectionsLimit           int      `env:"CONNECTIONS_LIMIT" envDefault:"50"`
 	MaxBodySize                int64    `env:"MAX_BODY_SIZE" envDefault:"10485760"` // 10 MB
 	RecipientRateLimitInterval int      `env:"RECIPIENT_RATE_LIMIT_INTERVAL" envDefault:"0"`
-	RecipientRateLimitRPI      int      `env:"RECIPIENT_RATE_LIMIT_RPI" envDefault:"1"` // Requests per interval
+	RecipientRateLimitRPI      int      `env:"RECIPIENT_RATE_LIMIT_RPI" envDefault:"1"`       // Requests per interval
+	RecipientRateLimitMaxSize  int      `env:"RECIPIENT_RATE_LIMIT_MAX_SIZE" envDefault:"10000"` // Max tracked recipients (LRU eviction, 0 = unlimited)
 	RateLimitsBypassToken      []string `env:"RATE_LIMITS_BYPASS_TOKEN"`
 
 	// Security

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -35,7 +35,8 @@ var Config = struct {
 	ConnectionsLimit           int      `env:"CONNECTIONS_LIMIT" envDefault:"50"`
 	MaxBodySize                int64    `env:"MAX_BODY_SIZE" envDefault:"10485760"` // 10 MB
 	RecipientRateLimitInterval int      `env:"RECIPIENT_RATE_LIMIT_INTERVAL" envDefault:"0"`
-	RateLimitsByPassToken      []string `env:"RATE_LIMITS_BY_PASS_TOKEN"`
+	RecipientRateLimitRPI      int      `env:"RECIPIENT_RATE_LIMIT_RPI" envDefault:"1"` // Requests per interval
+	RateLimitsBypassToken      []string `env:"RATE_LIMITS_BYPASS_TOKEN"`
 
 	// Security
 	CorsEnable         bool     `env:"CORS_ENABLE" envDefault:"true"`

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -34,7 +34,7 @@ var Config = struct {
 	RPSLimit                   int      `env:"RPS_LIMIT" envDefault:"10"`
 	ConnectionsLimit           int      `env:"CONNECTIONS_LIMIT" envDefault:"50"`
 	MaxBodySize                int64    `env:"MAX_BODY_SIZE" envDefault:"10485760"` // 10 MB
-	RecipientRateLimitInterval int      `env:"RECIPIENT_RATE_LIMIT_INTERVAL" envDefault:"10"`
+	RecipientRateLimitInterval int      `env:"RECIPIENT_RATE_LIMIT_INTERVAL" envDefault:"0"`
 	RateLimitsByPassToken      []string `env:"RATE_LIMITS_BY_PASS_TOKEN"`
 
 	// Security

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -35,7 +35,7 @@ var Config = struct {
 	ConnectionsLimit           int      `env:"CONNECTIONS_LIMIT" envDefault:"50"`
 	MaxBodySize                int64    `env:"MAX_BODY_SIZE" envDefault:"10485760"` // 10 MB
 	RecipientRateLimitInterval int      `env:"RECIPIENT_RATE_LIMIT_INTERVAL" envDefault:"0"`
-	RecipientRateLimitRPI      int      `env:"RECIPIENT_RATE_LIMIT_RPI" envDefault:"1"`       // Requests per interval
+	RecipientRateLimitRPI      int      `env:"RECIPIENT_RATE_LIMIT_RPI" envDefault:"1"`          // Requests per interval
 	RecipientRateLimitMaxSize  int      `env:"RECIPIENT_RATE_LIMIT_MAX_SIZE" envDefault:"10000"` // Max tracked recipients (LRU eviction, 0 = unlimited)
 	RateLimitsBypassToken      []string `env:"RATE_LIMITS_BYPASS_TOKEN"`
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -30,11 +30,12 @@ var Config = struct {
 	PostgresLazyConnect           bool   `env:"POSTGRES_LAZY_CONNECT" envDefault:"false"`
 
 	// Performance & Limits
-	HeartbeatInterval     int      `env:"HEARTBEAT_INTERVAL" envDefault:"10"`
-	RPSLimit              int      `env:"RPS_LIMIT" envDefault:"10"`
-	ConnectionsLimit      int      `env:"CONNECTIONS_LIMIT" envDefault:"50"`
-	MaxBodySize           int64    `env:"MAX_BODY_SIZE" envDefault:"10485760"` // 10 MB
-	RateLimitsByPassToken []string `env:"RATE_LIMITS_BY_PASS_TOKEN"`
+	HeartbeatInterval            int      `env:"HEARTBEAT_INTERVAL" envDefault:"10"`
+	RPSLimit                     int      `env:"RPS_LIMIT" envDefault:"10"`
+	ConnectionsLimit             int      `env:"CONNECTIONS_LIMIT" envDefault:"50"`
+	MaxBodySize                  int64    `env:"MAX_BODY_SIZE" envDefault:"10485760"` // 10 MB
+	RecipientRateLimitInterval int      `env:"RECIPIENT_RATE_LIMIT_INTERVAL" envDefault:"10"`
+	RateLimitsByPassToken      []string `env:"RATE_LIMITS_BY_PASS_TOKEN"`
 
 	// Security
 	CorsEnable         bool     `env:"CORS_ENABLE" envDefault:"true"`

--- a/internal/middleware/recipient_ratelimit.go
+++ b/internal/middleware/recipient_ratelimit.go
@@ -1,0 +1,97 @@
+package middleware
+
+import (
+	"sync"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/sirupsen/logrus"
+	"golang.org/x/time/rate"
+)
+
+var recipientRateLimitedMetric = promauto.NewCounter(prometheus.CounterOpts{
+	Name: "number_of_recipient_rate_limited_messages",
+	Help: "The total number of messages dropped by per-recipient rate limiting",
+})
+
+// RecipientRateLimiter enforces a per-recipient (to) push rate limit using a leaky bucket.
+type RecipientRateLimiter struct {
+	mu        sync.Mutex
+	limiters  map[string]*rateLimiterEntry
+	interval  time.Duration
+	cleanupCh chan struct{}
+}
+
+type rateLimiterEntry struct {
+	limiter  *rate.Limiter
+	lastSeen time.Time
+}
+
+// NewRecipientRateLimiter creates a rate limiter that allows 1 push per interval per recipient.
+// If interval is 0, rate limiting is disabled.
+func NewRecipientRateLimiter(interval time.Duration) *RecipientRateLimiter {
+	rl := &RecipientRateLimiter{
+		limiters:  make(map[string]*rateLimiterEntry),
+		interval:  interval,
+		cleanupCh: make(chan struct{}),
+	}
+	if interval > 0 {
+		go rl.cleanup()
+	}
+	return rl
+}
+
+// Allow checks if a push to the given recipient is allowed.
+// Returns true if allowed, false if rate limited.
+func (rl *RecipientRateLimiter) Allow(to string) bool {
+	if rl.interval <= 0 {
+		return true
+	}
+
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+
+	entry, exists := rl.limiters[to]
+	if !exists {
+		// 1 event per interval, burst of 1
+		lim := rate.NewLimiter(rate.Every(rl.interval), 1)
+		entry = &rateLimiterEntry{limiter: lim, lastSeen: time.Now()}
+		rl.limiters[to] = entry
+	}
+	entry.lastSeen = time.Now()
+
+	if !entry.limiter.Allow() {
+		recipientRateLimitedMetric.Inc()
+		logrus.WithField("to", to).Warn("Message rate limited for recipient")
+		return false
+	}
+	return true
+}
+
+// cleanup periodically removes stale limiters for recipients that haven't been seen recently.
+func (rl *RecipientRateLimiter) cleanup() {
+	ticker := time.NewTicker(time.Minute)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			rl.mu.Lock()
+			cutoff := time.Now().Add(-5 * rl.interval)
+			for key, entry := range rl.limiters {
+				if entry.lastSeen.Before(cutoff) {
+					delete(rl.limiters, key)
+				}
+			}
+			rl.mu.Unlock()
+		case <-rl.cleanupCh:
+			return
+		}
+	}
+}
+
+// Stop terminates the background cleanup goroutine.
+func (rl *RecipientRateLimiter) Stop() {
+	close(rl.cleanupCh)
+}

--- a/internal/middleware/recipient_ratelimit.go
+++ b/internal/middleware/recipient_ratelimit.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	"container/list"
 	"sync"
 	"time"
 
@@ -16,27 +17,34 @@ var recipientRateLimitedMetric = promauto.NewCounter(prometheus.CounterOpts{
 })
 
 // RecipientRateLimiter enforces a per-recipient (to) push rate limit using a leaky bucket.
+// When maxSize > 0, it uses LRU eviction to bound memory usage.
 type RecipientRateLimiter struct {
 	mu        sync.Mutex
-	limiters  map[string]*rateLimiterEntry
+	limiters  map[string]*list.Element
+	evictList *list.List
+	maxSize   int
 	interval  time.Duration
 	burst     int
 	cleanupCh chan struct{}
 }
 
 type rateLimiterEntry struct {
+	key      string
 	limiter  *rate.Limiter
 	lastSeen time.Time
 }
 
 // NewRecipientRateLimiter creates a rate limiter that allows rpi pushes per interval per recipient.
+// maxSize bounds the number of tracked recipients; 0 means unlimited.
 // If interval is 0, rate limiting is disabled.
-func NewRecipientRateLimiter(interval time.Duration, rpi int) *RecipientRateLimiter {
+func NewRecipientRateLimiter(interval time.Duration, rpi int, maxSize int) *RecipientRateLimiter {
 	if rpi < 1 {
 		rpi = 1
 	}
 	rl := &RecipientRateLimiter{
-		limiters:  make(map[string]*rateLimiterEntry),
+		limiters:  make(map[string]*list.Element),
+		evictList: list.New(),
+		maxSize:   maxSize,
 		interval:  interval,
 		burst:     rpi,
 		cleanupCh: make(chan struct{}),
@@ -57,12 +65,21 @@ func (rl *RecipientRateLimiter) Allow(to string) bool {
 	rl.mu.Lock()
 	defer rl.mu.Unlock()
 
-	entry, exists := rl.limiters[to]
+	elem, exists := rl.limiters[to]
 	if !exists {
+		// Evict oldest if at capacity
+		if rl.maxSize > 0 && rl.evictList.Len() >= rl.maxSize {
+			rl.removeOldest()
+		}
 		lim := rate.NewLimiter(rate.Every(rl.interval/time.Duration(rl.burst)), rl.burst)
-		entry = &rateLimiterEntry{limiter: lim, lastSeen: time.Now()}
-		rl.limiters[to] = entry
+		entry := &rateLimiterEntry{key: to, limiter: lim, lastSeen: time.Now()}
+		elem = rl.evictList.PushFront(entry)
+		rl.limiters[to] = elem
+	} else {
+		rl.evictList.MoveToFront(elem)
 	}
+
+	entry := elem.Value.(*rateLimiterEntry)
 	entry.lastSeen = time.Now()
 
 	if !entry.limiter.Allow() {
@@ -71,6 +88,22 @@ func (rl *RecipientRateLimiter) Allow(to string) bool {
 		return false
 	}
 	return true
+}
+
+// removeOldest evicts the least recently used entry. Must be called with mu held.
+func (rl *RecipientRateLimiter) removeOldest() {
+	elem := rl.evictList.Back()
+	if elem == nil {
+		return
+	}
+	rl.removeElement(elem)
+}
+
+// removeElement removes a specific element from the cache. Must be called with mu held.
+func (rl *RecipientRateLimiter) removeElement(elem *list.Element) {
+	rl.evictList.Remove(elem)
+	entry := elem.Value.(*rateLimiterEntry)
+	delete(rl.limiters, entry.key)
 }
 
 // cleanup periodically removes stale limiters for recipients that haven't been seen recently.
@@ -83,9 +116,17 @@ func (rl *RecipientRateLimiter) cleanup() {
 		case <-ticker.C:
 			rl.mu.Lock()
 			cutoff := time.Now().Add(-5 * rl.interval)
-			for key, entry := range rl.limiters {
+			// Iterate from back (oldest) and remove stale entries
+			for {
+				elem := rl.evictList.Back()
+				if elem == nil {
+					break
+				}
+				entry := elem.Value.(*rateLimiterEntry)
 				if entry.lastSeen.Before(cutoff) {
-					delete(rl.limiters, key)
+					rl.removeElement(elem)
+				} else {
+					break
 				}
 			}
 			rl.mu.Unlock()

--- a/internal/middleware/recipient_ratelimit.go
+++ b/internal/middleware/recipient_ratelimit.go
@@ -20,6 +20,7 @@ type RecipientRateLimiter struct {
 	mu        sync.Mutex
 	limiters  map[string]*rateLimiterEntry
 	interval  time.Duration
+	burst     int
 	cleanupCh chan struct{}
 }
 
@@ -28,12 +29,16 @@ type rateLimiterEntry struct {
 	lastSeen time.Time
 }
 
-// NewRecipientRateLimiter creates a rate limiter that allows 1 push per interval per recipient.
+// NewRecipientRateLimiter creates a rate limiter that allows rpi pushes per interval per recipient.
 // If interval is 0, rate limiting is disabled.
-func NewRecipientRateLimiter(interval time.Duration) *RecipientRateLimiter {
+func NewRecipientRateLimiter(interval time.Duration, rpi int) *RecipientRateLimiter {
+	if rpi < 1 {
+		rpi = 1
+	}
 	rl := &RecipientRateLimiter{
 		limiters:  make(map[string]*rateLimiterEntry),
 		interval:  interval,
+		burst:     rpi,
 		cleanupCh: make(chan struct{}),
 	}
 	if interval > 0 {
@@ -54,8 +59,7 @@ func (rl *RecipientRateLimiter) Allow(to string) bool {
 
 	entry, exists := rl.limiters[to]
 	if !exists {
-		// 1 event per interval, burst of 1
-		lim := rate.NewLimiter(rate.Every(rl.interval), 1)
+		lim := rate.NewLimiter(rate.Every(rl.interval/time.Duration(rl.burst)), rl.burst)
 		entry = &rateLimiterEntry{limiter: lim, lastSeen: time.Now()}
 		rl.limiters[to] = entry
 	}

--- a/internal/middleware/recipient_ratelimit_test.go
+++ b/internal/middleware/recipient_ratelimit_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestRecipientRateLimiter_DisabledWhenZeroInterval(t *testing.T) {
-	rl := NewRecipientRateLimiter(0)
+	rl := NewRecipientRateLimiter(0, 1)
 	defer rl.Stop()
 
 	for i := 0; i < 100; i++ {
@@ -18,7 +18,7 @@ func TestRecipientRateLimiter_DisabledWhenZeroInterval(t *testing.T) {
 }
 
 func TestRecipientRateLimiter_AllowsFirstRequest(t *testing.T) {
-	rl := NewRecipientRateLimiter(time.Second)
+	rl := NewRecipientRateLimiter(time.Second, 1)
 	defer rl.Stop()
 
 	if !rl.Allow("recipient1") {
@@ -27,7 +27,7 @@ func TestRecipientRateLimiter_AllowsFirstRequest(t *testing.T) {
 }
 
 func TestRecipientRateLimiter_BlocksSecondRequest(t *testing.T) {
-	rl := NewRecipientRateLimiter(time.Second)
+	rl := NewRecipientRateLimiter(time.Second, 1)
 	defer rl.Stop()
 
 	if !rl.Allow("recipient1") {
@@ -39,7 +39,7 @@ func TestRecipientRateLimiter_BlocksSecondRequest(t *testing.T) {
 }
 
 func TestRecipientRateLimiter_IndependentRecipients(t *testing.T) {
-	rl := NewRecipientRateLimiter(time.Second)
+	rl := NewRecipientRateLimiter(time.Second, 1)
 	defer rl.Stop()
 
 	if !rl.Allow("recipient1") {
@@ -57,7 +57,7 @@ func TestRecipientRateLimiter_IndependentRecipients(t *testing.T) {
 }
 
 func TestRecipientRateLimiter_AllowsAfterInterval(t *testing.T) {
-	rl := NewRecipientRateLimiter(50 * time.Millisecond)
+	rl := NewRecipientRateLimiter(50*time.Millisecond, 1)
 	defer rl.Stop()
 
 	if !rl.Allow("recipient1") {
@@ -75,7 +75,7 @@ func TestRecipientRateLimiter_AllowsAfterInterval(t *testing.T) {
 }
 
 func TestRecipientRateLimiter_ConcurrentAccess(t *testing.T) {
-	rl := NewRecipientRateLimiter(time.Second)
+	rl := NewRecipientRateLimiter(time.Second, 1)
 	defer rl.Stop()
 
 	var wg sync.WaitGroup
@@ -102,7 +102,7 @@ func TestRecipientRateLimiter_ConcurrentAccess(t *testing.T) {
 }
 
 func TestRecipientRateLimiter_Cleanup(t *testing.T) {
-	rl := NewRecipientRateLimiter(10 * time.Millisecond)
+	rl := NewRecipientRateLimiter(10*time.Millisecond, 1)
 	defer rl.Stop()
 
 	rl.Allow("recipient1")
@@ -123,5 +123,115 @@ func TestRecipientRateLimiter_Cleanup(t *testing.T) {
 
 	if count != 0 {
 		t.Fatalf("expected stale limiter to be cleaned up, got %d entries", count)
+	}
+}
+
+func TestRecipientRateLimiter_BurstAllowsNRequests(t *testing.T) {
+	rl := NewRecipientRateLimiter(time.Second, 3)
+	defer rl.Stop()
+
+	for i := 0; i < 3; i++ {
+		if !rl.Allow("recipient1") {
+			t.Fatalf("expected request %d to be allowed within burst", i+1)
+		}
+	}
+	if rl.Allow("recipient1") {
+		t.Fatal("expected request 4 to be blocked after burst exhausted")
+	}
+}
+
+func TestRecipientRateLimiter_BurstRefillsAfterFullInterval(t *testing.T) {
+	rl := NewRecipientRateLimiter(90*time.Millisecond, 3)
+	defer rl.Stop()
+
+	for i := 0; i < 3; i++ {
+		if !rl.Allow("recipient1") {
+			t.Fatalf("expected request %d to be allowed within burst", i+1)
+		}
+	}
+	if rl.Allow("recipient1") {
+		t.Fatal("expected request 4 to be blocked after burst exhausted")
+	}
+
+	time.Sleep(100 * time.Millisecond)
+
+	for i := 0; i < 3; i++ {
+		if !rl.Allow("recipient1") {
+			t.Fatalf("expected request %d to be allowed after full interval refill", i+1)
+		}
+	}
+	if rl.Allow("recipient1") {
+		t.Fatal("expected request 4 to be blocked again after second burst exhausted")
+	}
+}
+
+func TestRecipientRateLimiter_BurstPartialRefill(t *testing.T) {
+	rl := NewRecipientRateLimiter(90*time.Millisecond, 3)
+	defer rl.Stop()
+
+	for i := 0; i < 3; i++ {
+		if !rl.Allow("recipient1") {
+			t.Fatalf("expected request %d to be allowed within burst", i+1)
+		}
+	}
+
+	time.Sleep(40 * time.Millisecond)
+
+	if !rl.Allow("recipient1") {
+		t.Fatal("expected one request to be allowed after partial refill")
+	}
+	if rl.Allow("recipient1") {
+		t.Fatal("expected second request to be blocked after partial refill consumed")
+	}
+}
+
+func TestRecipientRateLimiter_BurstIndependentRecipients(t *testing.T) {
+	rl := NewRecipientRateLimiter(time.Second, 3)
+	defer rl.Stop()
+
+	for i := 0; i < 3; i++ {
+		if !rl.Allow("recipient1") {
+			t.Fatalf("expected request %d to recipient1 to be allowed", i+1)
+		}
+	}
+	if rl.Allow("recipient1") {
+		t.Fatal("expected recipient1 to be blocked after burst exhausted")
+	}
+
+	for i := 0; i < 3; i++ {
+		if !rl.Allow("recipient2") {
+			t.Fatalf("expected request %d to recipient2 to be allowed", i+1)
+		}
+	}
+	if rl.Allow("recipient2") {
+		t.Fatal("expected recipient2 to be blocked after burst exhausted")
+	}
+}
+
+func TestRecipientRateLimiter_ConcurrentBurst(t *testing.T) {
+	rl := NewRecipientRateLimiter(time.Second, 3)
+	defer rl.Stop()
+
+	const goroutines = 20
+	var wg sync.WaitGroup
+	allowed := make([]int, goroutines)
+
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			if rl.Allow("recipient1") {
+				allowed[idx] = 1
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	total := 0
+	for _, v := range allowed {
+		total += v
+	}
+	if total != 3 {
+		t.Fatalf("expected exactly 3 allowed requests with burst=3, got %d", total)
 	}
 }

--- a/internal/middleware/recipient_ratelimit_test.go
+++ b/internal/middleware/recipient_ratelimit_test.go
@@ -1,13 +1,14 @@
 package middleware
 
 import (
+	"fmt"
 	"sync"
 	"testing"
 	"time"
 )
 
 func TestRecipientRateLimiter_DisabledWhenZeroInterval(t *testing.T) {
-	rl := NewRecipientRateLimiter(0, 1)
+	rl := NewRecipientRateLimiter(0, 1, 0)
 	defer rl.Stop()
 
 	for i := 0; i < 100; i++ {
@@ -18,7 +19,7 @@ func TestRecipientRateLimiter_DisabledWhenZeroInterval(t *testing.T) {
 }
 
 func TestRecipientRateLimiter_AllowsFirstRequest(t *testing.T) {
-	rl := NewRecipientRateLimiter(time.Second, 1)
+	rl := NewRecipientRateLimiter(time.Second, 1, 0)
 	defer rl.Stop()
 
 	if !rl.Allow("recipient1") {
@@ -27,7 +28,7 @@ func TestRecipientRateLimiter_AllowsFirstRequest(t *testing.T) {
 }
 
 func TestRecipientRateLimiter_BlocksSecondRequest(t *testing.T) {
-	rl := NewRecipientRateLimiter(time.Second, 1)
+	rl := NewRecipientRateLimiter(time.Second, 1, 0)
 	defer rl.Stop()
 
 	if !rl.Allow("recipient1") {
@@ -39,7 +40,7 @@ func TestRecipientRateLimiter_BlocksSecondRequest(t *testing.T) {
 }
 
 func TestRecipientRateLimiter_IndependentRecipients(t *testing.T) {
-	rl := NewRecipientRateLimiter(time.Second, 1)
+	rl := NewRecipientRateLimiter(time.Second, 1, 0)
 	defer rl.Stop()
 
 	if !rl.Allow("recipient1") {
@@ -57,7 +58,7 @@ func TestRecipientRateLimiter_IndependentRecipients(t *testing.T) {
 }
 
 func TestRecipientRateLimiter_AllowsAfterInterval(t *testing.T) {
-	rl := NewRecipientRateLimiter(50*time.Millisecond, 1)
+	rl := NewRecipientRateLimiter(50*time.Millisecond, 1, 0)
 	defer rl.Stop()
 
 	if !rl.Allow("recipient1") {
@@ -75,7 +76,7 @@ func TestRecipientRateLimiter_AllowsAfterInterval(t *testing.T) {
 }
 
 func TestRecipientRateLimiter_ConcurrentAccess(t *testing.T) {
-	rl := NewRecipientRateLimiter(time.Second, 1)
+	rl := NewRecipientRateLimiter(time.Second, 1, 0)
 	defer rl.Stop()
 
 	var wg sync.WaitGroup
@@ -102,7 +103,7 @@ func TestRecipientRateLimiter_ConcurrentAccess(t *testing.T) {
 }
 
 func TestRecipientRateLimiter_Cleanup(t *testing.T) {
-	rl := NewRecipientRateLimiter(10*time.Millisecond, 1)
+	rl := NewRecipientRateLimiter(10*time.Millisecond, 1, 0)
 	defer rl.Stop()
 
 	rl.Allow("recipient1")
@@ -113,8 +114,10 @@ func TestRecipientRateLimiter_Cleanup(t *testing.T) {
 
 	rl.mu.Lock()
 	cutoff := time.Now().Add(-5 * rl.interval)
-	for key, entry := range rl.limiters {
+	for key, elem := range rl.limiters {
+		entry := elem.Value.(*rateLimiterEntry)
 		if entry.lastSeen.Before(cutoff) {
+			rl.evictList.Remove(elem)
 			delete(rl.limiters, key)
 		}
 	}
@@ -127,7 +130,7 @@ func TestRecipientRateLimiter_Cleanup(t *testing.T) {
 }
 
 func TestRecipientRateLimiter_BurstAllowsNRequests(t *testing.T) {
-	rl := NewRecipientRateLimiter(time.Second, 3)
+	rl := NewRecipientRateLimiter(time.Second, 3, 0)
 	defer rl.Stop()
 
 	for i := 0; i < 3; i++ {
@@ -141,7 +144,7 @@ func TestRecipientRateLimiter_BurstAllowsNRequests(t *testing.T) {
 }
 
 func TestRecipientRateLimiter_BurstRefillsAfterFullInterval(t *testing.T) {
-	rl := NewRecipientRateLimiter(90*time.Millisecond, 3)
+	rl := NewRecipientRateLimiter(90*time.Millisecond, 3, 0)
 	defer rl.Stop()
 
 	for i := 0; i < 3; i++ {
@@ -166,7 +169,7 @@ func TestRecipientRateLimiter_BurstRefillsAfterFullInterval(t *testing.T) {
 }
 
 func TestRecipientRateLimiter_BurstPartialRefill(t *testing.T) {
-	rl := NewRecipientRateLimiter(90*time.Millisecond, 3)
+	rl := NewRecipientRateLimiter(90*time.Millisecond, 3, 0)
 	defer rl.Stop()
 
 	for i := 0; i < 3; i++ {
@@ -186,7 +189,7 @@ func TestRecipientRateLimiter_BurstPartialRefill(t *testing.T) {
 }
 
 func TestRecipientRateLimiter_BurstIndependentRecipients(t *testing.T) {
-	rl := NewRecipientRateLimiter(time.Second, 3)
+	rl := NewRecipientRateLimiter(time.Second, 3, 0)
 	defer rl.Stop()
 
 	for i := 0; i < 3; i++ {
@@ -209,7 +212,7 @@ func TestRecipientRateLimiter_BurstIndependentRecipients(t *testing.T) {
 }
 
 func TestRecipientRateLimiter_ConcurrentBurst(t *testing.T) {
-	rl := NewRecipientRateLimiter(time.Second, 3)
+	rl := NewRecipientRateLimiter(time.Second, 3, 0)
 	defer rl.Stop()
 
 	const goroutines = 20
@@ -234,4 +237,194 @@ func TestRecipientRateLimiter_ConcurrentBurst(t *testing.T) {
 	if total != 3 {
 		t.Fatalf("expected exactly 3 allowed requests with burst=3, got %d", total)
 	}
+}
+
+func TestRecipientRateLimiter_LRU_EvictsOldest(t *testing.T) {
+	rl := NewRecipientRateLimiter(time.Second, 1, 2)
+	defer rl.Stop()
+
+	// Fill capacity with r1, r2
+	rl.Allow("r1")
+	rl.Allow("r2")
+
+	// r1 is now the oldest (LRU). Adding r3 should evict r1.
+	rl.Allow("r3")
+
+	rl.mu.Lock()
+	_, r1Exists := rl.limiters["r1"]
+	_, r2Exists := rl.limiters["r2"]
+	_, r3Exists := rl.limiters["r3"]
+	size := len(rl.limiters)
+	rl.mu.Unlock()
+
+	if r1Exists {
+		t.Fatal("expected r1 to be evicted")
+	}
+	if !r2Exists || !r3Exists {
+		t.Fatal("expected r2 and r3 to remain")
+	}
+	if size != 2 {
+		t.Fatalf("expected 2 entries, got %d", size)
+	}
+}
+
+func TestRecipientRateLimiter_LRU_AccessRefreshesOrder(t *testing.T) {
+	rl := NewRecipientRateLimiter(time.Second, 1, 2)
+	defer rl.Stop()
+
+	rl.Allow("r1")
+	rl.Allow("r2")
+
+	// Access r1 again to make it most-recently-used
+	rl.Allow("r1")
+
+	// Now r2 is the oldest. Adding r3 should evict r2, not r1.
+	rl.Allow("r3")
+
+	rl.mu.Lock()
+	_, r1Exists := rl.limiters["r1"]
+	_, r2Exists := rl.limiters["r2"]
+	_, r3Exists := rl.limiters["r3"]
+	rl.mu.Unlock()
+
+	if !r1Exists {
+		t.Fatal("expected r1 to remain (was recently accessed)")
+	}
+	if r2Exists {
+		t.Fatal("expected r2 to be evicted (oldest)")
+	}
+	if !r3Exists {
+		t.Fatal("expected r3 to remain")
+	}
+}
+
+func TestRecipientRateLimiter_LRU_EvictedRecipientGetsNewBucket(t *testing.T) {
+	rl := NewRecipientRateLimiter(time.Second, 1, 2)
+	defer rl.Stop()
+
+	// Exhaust r1's bucket
+	rl.Allow("r1")
+	rl.Allow("r2")
+
+	// Evict r1 by adding r3
+	rl.Allow("r3")
+
+	// r1 was evicted, so it gets a fresh bucket — should be allowed
+	if !rl.Allow("r1") {
+		t.Fatal("expected r1 to be allowed after eviction (fresh bucket)")
+	}
+}
+
+func TestRecipientRateLimiter_LRU_UnlimitedWhenZeroMaxSize(t *testing.T) {
+	rl := NewRecipientRateLimiter(time.Second, 1, 0)
+	defer rl.Stop()
+
+	for i := 0; i < 10000; i++ {
+		rl.Allow(fmt.Sprintf("r%d", i))
+	}
+
+	rl.mu.Lock()
+	size := len(rl.limiters)
+	rl.mu.Unlock()
+
+	if size != 10000 {
+		t.Fatalf("expected 10000 entries with unlimited maxSize, got %d", size)
+	}
+}
+
+// Benchmarks — measure raw overhead of Allow() with huge burst so rate limiting never triggers.
+
+// BenchmarkAllow_Disabled: baseline with rate limiting off (interval=0).
+func BenchmarkAllow_Disabled(b *testing.B) {
+	rl := NewRecipientRateLimiter(0, 1000000, 0)
+	defer rl.Stop()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		rl.Allow("recipient1")
+	}
+}
+
+// BenchmarkAllow_SingleRecipient: one recipient, never hits the limit.
+func BenchmarkAllow_SingleRecipient(b *testing.B) {
+	rl := NewRecipientRateLimiter(time.Hour, 1000000000, 0)
+	defer rl.Stop()
+
+	rl.Allow("recipient1") // warm up the entry
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		rl.Allow("recipient1")
+	}
+}
+
+// BenchmarkAllow_SingleRecipient_LRU: same but with LRU bounded (maxSize=1000).
+func BenchmarkAllow_SingleRecipient_LRU(b *testing.B) {
+	rl := NewRecipientRateLimiter(time.Hour, 1000000000, 1000)
+	defer rl.Stop()
+
+	rl.Allow("recipient1")
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		rl.Allow("recipient1")
+	}
+}
+
+// BenchmarkAllow_ManyRecipients: unique recipient each call, no LRU cap — measures map insert cost.
+func BenchmarkAllow_ManyRecipients(b *testing.B) {
+	rl := NewRecipientRateLimiter(time.Hour, 1000000000, 0)
+	defer rl.Stop()
+
+	keys := make([]string, b.N)
+	for i := range keys {
+		keys[i] = fmt.Sprintf("r%d", i)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		rl.Allow(keys[i])
+	}
+}
+
+// BenchmarkAllow_ManyRecipients_LRU: unique recipients with LRU eviction active (maxSize=10000).
+func BenchmarkAllow_ManyRecipients_LRU(b *testing.B) {
+	rl := NewRecipientRateLimiter(time.Hour, 1000000000, 10000)
+	defer rl.Stop()
+
+	keys := make([]string, b.N)
+	for i := range keys {
+		keys[i] = fmt.Sprintf("r%d", i)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		rl.Allow(keys[i])
+	}
+}
+
+// BenchmarkAllow_Parallel: concurrent access from multiple goroutines, single recipient.
+func BenchmarkAllow_Parallel(b *testing.B) {
+	rl := NewRecipientRateLimiter(time.Hour, 1000000000, 0)
+	defer rl.Stop()
+
+	rl.Allow("recipient1")
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			rl.Allow("recipient1")
+		}
+	})
+}
+
+// BenchmarkAllow_Parallel_LRU: concurrent access with LRU enabled.
+func BenchmarkAllow_Parallel_LRU(b *testing.B) {
+	rl := NewRecipientRateLimiter(time.Hour, 1000000000, 10000)
+	defer rl.Stop()
+
+	rl.Allow("recipient1")
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			rl.Allow("recipient1")
+		}
+	})
 }

--- a/internal/middleware/recipient_ratelimit_test.go
+++ b/internal/middleware/recipient_ratelimit_test.go
@@ -1,0 +1,127 @@
+package middleware
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestRecipientRateLimiter_DisabledWhenZeroInterval(t *testing.T) {
+	rl := NewRecipientRateLimiter(0)
+	defer rl.Stop()
+
+	for i := 0; i < 100; i++ {
+		if !rl.Allow("recipient1") {
+			t.Fatalf("expected Allow to return true when interval is 0, blocked on call %d", i)
+		}
+	}
+}
+
+func TestRecipientRateLimiter_AllowsFirstRequest(t *testing.T) {
+	rl := NewRecipientRateLimiter(time.Second)
+	defer rl.Stop()
+
+	if !rl.Allow("recipient1") {
+		t.Fatal("expected first request to be allowed")
+	}
+}
+
+func TestRecipientRateLimiter_BlocksSecondRequest(t *testing.T) {
+	rl := NewRecipientRateLimiter(time.Second)
+	defer rl.Stop()
+
+	if !rl.Allow("recipient1") {
+		t.Fatal("expected first request to be allowed")
+	}
+	if rl.Allow("recipient1") {
+		t.Fatal("expected second request within interval to be blocked")
+	}
+}
+
+func TestRecipientRateLimiter_IndependentRecipients(t *testing.T) {
+	rl := NewRecipientRateLimiter(time.Second)
+	defer rl.Stop()
+
+	if !rl.Allow("recipient1") {
+		t.Fatal("expected first request to recipient1 to be allowed")
+	}
+	if !rl.Allow("recipient2") {
+		t.Fatal("expected first request to recipient2 to be allowed")
+	}
+	if rl.Allow("recipient1") {
+		t.Fatal("expected second request to recipient1 to be blocked")
+	}
+	if rl.Allow("recipient2") {
+		t.Fatal("expected second request to recipient2 to be blocked")
+	}
+}
+
+func TestRecipientRateLimiter_AllowsAfterInterval(t *testing.T) {
+	rl := NewRecipientRateLimiter(50 * time.Millisecond)
+	defer rl.Stop()
+
+	if !rl.Allow("recipient1") {
+		t.Fatal("expected first request to be allowed")
+	}
+	if rl.Allow("recipient1") {
+		t.Fatal("expected second request to be blocked")
+	}
+
+	time.Sleep(60 * time.Millisecond)
+
+	if !rl.Allow("recipient1") {
+		t.Fatal("expected request after interval to be allowed")
+	}
+}
+
+func TestRecipientRateLimiter_ConcurrentAccess(t *testing.T) {
+	rl := NewRecipientRateLimiter(time.Second)
+	defer rl.Stop()
+
+	var wg sync.WaitGroup
+	allowed := make([]int, 10)
+
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			if rl.Allow("recipient1") {
+				allowed[idx] = 1
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	total := 0
+	for _, v := range allowed {
+		total += v
+	}
+	if total != 1 {
+		t.Fatalf("expected exactly 1 allowed request, got %d", total)
+	}
+}
+
+func TestRecipientRateLimiter_Cleanup(t *testing.T) {
+	rl := NewRecipientRateLimiter(10 * time.Millisecond)
+	defer rl.Stop()
+
+	rl.Allow("recipient1")
+
+	// Wait long enough for cleanup to remove stale entry (5*interval = 50ms, cleanup runs every minute)
+	// Instead of waiting for the ticker, invoke cleanup logic indirectly by checking the map
+	time.Sleep(60 * time.Millisecond)
+
+	rl.mu.Lock()
+	cutoff := time.Now().Add(-5 * rl.interval)
+	for key, entry := range rl.limiters {
+		if entry.lastSeen.Before(cutoff) {
+			delete(rl.limiters, key)
+		}
+	}
+	count := len(rl.limiters)
+	rl.mu.Unlock()
+
+	if count != 0 {
+		t.Fatalf("expected stale limiter to be cleaned up, got %d entries", count)
+	}
+}


### PR DESCRIPTION
  - Per-recipient rate limit on /bridge/message — prevents flooding a single to address
  - Leaky bucket: 1 msg per interval (default 10s), configurable via RECIPIENT_RATE_LIMIT_INTERVAL, 0 to disable
  - Implemented as Echo middleware, applied to both v1 and v3 bridge apps
  - Bypass token (RATE_LIMITS_BY_PASS_TOKEN) is respected
  - Returns 429 when limit is hit