### PR TITLE
CI: container image build + release pointer gate

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -1,0 +1,20 @@
+name: Build image
+
+# Build and publish the bridge v3 container image via the shared workflow.
+# Push-only triggers: the shared job mints short-lived cloud credentials via
+# OIDC, so it must never run for fork pull requests (no pull_request trigger).
+on:
+  push:
+    branches: [master, 'release/**']
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  build:
+    uses: ton-connect/ci/.github/workflows/build-image.yml@main
+    with:
+      ecr-repository: bridge
+      role-arn: arn:aws:iam::990678687129:role/gha-ecr-push-bridge
+      dockerfile: docker/Dockerfile.bridge3

--- a/.github/workflows/verify-release-pointer.yml
+++ b/.github/workflows/verify-release-pointer.yml
@@ -1,0 +1,17 @@
+name: Verify release pointer
+
+# Validates edits to version.yaml — the release pointer that selects the
+# published image to deploy. Runs on every pull request (no paths filter) so it
+# always reports a status; the shared job no-ops when version.yaml is untouched.
+on: pull_request
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  verify:
+    uses: ton-connect/ci/.github/workflows/verify-release-pointer.yml@main
+    with:
+      ecr-repository: bridge
+      role-arn: arn:aws:iam::990678687129:role/gha-ecr-read-bridge

--- a/service.yaml
+++ b/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: idp.mw.me/v1
+name: bridge
+port: 8081
+arch: arm64
+replicas: 2
+resources:
+  requests: { cpu: 100m, memory: 128Mi }
+  limits: { cpu: 500m, memory: 256Mi }
+healthcheck:
+  port: 9103
+  readiness-path: /ready
+  liveness-path: /health
+env:
+  STORAGE: valkey


### PR DESCRIPTION
Adds container build/release plumbing for bridge v3:

- `.github/workflows/build-image.yml` — builds `docker/Dockerfile.bridge3` on every push to `master`/`release/**` and publishes it to the container registry, tagged with the full and short commit sha (immutable tags, idempotent re-runs). Calls the shared workflow from `ton-connect/ci`.
- `.github/workflows/verify-release-pointer.yml` — validates `version.yaml` release-pointer PRs (schema, commit provenance, published-image existence), same shared-workflow setup.
- `service.yaml` — deployment descriptor (port, resources, healthcheck, storage backend) consumed by the deployment tooling.

Existing workflows (`build.yml`, `deploy-*`, tests) are untouched.