### PR TITLE
Add release pointer at 7db5dce

### DIFF
--- a/version.yaml
+++ b/version.yaml
@@ -1,0 +1,5 @@
+# Release pointer: the published deployment tracks exactly this commit.
+# Changes to this file intentionally do not trigger image builds.
+release:
+  branch: master
+  sha: 7db5dce


### PR DESCRIPTION
Introduces `version.yaml` — the release pointer that selects the published image to deploy. Pins the current master head `7db5dce` (already built and published). Validated by the `verify-release-pointer` check: schema, commit provenance, image existence.