### PR TITLE
Graceful shutdown on SIGTERM with /healthz and /readyz

### DIFF
--- a/cmd/bridge/main.go
+++ b/cmd/bridge/main.go
@@ -2,9 +2,12 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/pprof"
+	"os/signal"
+	"syscall"
 	"time"
 
 	"github.com/labstack/echo-contrib/prometheus"
@@ -28,6 +31,8 @@ import (
 func main() {
 	log.Info(fmt.Sprintf("Bridge %s is running", internal.BridgeVersionRevision))
 	config.LoadConfig()
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
+	defer stop()
 	app.InitMetrics()
 	if config.Config.PostgresURI == "" {
 		app.SetBridgeInfo("bridgev1", "memory")
@@ -66,6 +71,8 @@ func main() {
 	mux := http.NewServeMux()
 	mux.Handle("/health", http.HandlerFunc(healthManager.HealthHandler))
 	mux.Handle("/ready", http.HandlerFunc(healthManager.HealthHandler))
+	mux.Handle("/healthz", http.HandlerFunc(healthManager.LivenessHandler))
+	mux.Handle("/readyz", http.HandlerFunc(healthManager.ReadinessHandler))
 	mux.Handle("/version", http.HandlerFunc(app.VersionHandler))
 	mux.Handle("/metrics", promhttp.Handler())
 	if config.Config.PprofEnabled {
@@ -124,13 +131,34 @@ func main() {
 		return !slices.Contains(existedPaths, c.Path())
 	})
 	e.Use(p.HandlerFunc)
-	if config.Config.SelfSignedTLS {
-		cert, key, err := utils.GenerateSelfSignedCertificate()
-		if err != nil {
-			log.Fatalf("failed to generate self signed certificate: %v", err)
+	go func() {
+		var err error
+		if config.Config.SelfSignedTLS {
+			cert, key, certErr := utils.GenerateSelfSignedCertificate()
+			if certErr != nil {
+				log.Fatalf("failed to generate self signed certificate: %v", certErr)
+			}
+			err = e.StartTLS(fmt.Sprintf(":%v", config.Config.Port), cert, key)
+		} else {
+			err = e.Start(fmt.Sprintf(":%v", config.Config.Port))
 		}
-		log.Fatal(e.StartTLS(fmt.Sprintf(":%v", config.Config.Port), cert, key))
-	} else {
-		log.Fatal(e.Start(fmt.Sprintf(":%v", config.Config.Port)))
+		// Shutdown closes the listener and returns ErrServerClosed, the normal stop path.
+		if err != nil && !errors.Is(err, http.ErrServerClosed) {
+			log.Fatalf("bridge server: %v", err)
+		}
+	}()
+
+	<-ctx.Done()
+	// Graceful shutdown: flip /readyz to 503 so the load balancer takes the pod out of rotation
+	// while it is still listening, wait the drain window, then drain in-flight requests. SSE streams
+	// never complete on their own, so the bounded ShutdownTimeout ends the wait (clients reconnect).
+	log.Info("SIGTERM received, draining")
+	healthManager.SetDraining()
+	time.Sleep(time.Duration(config.Config.ShutdownDrainDelay) * time.Second)
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), time.Duration(config.Config.ShutdownTimeout)*time.Second)
+	defer cancel()
+	if err := e.Shutdown(shutdownCtx); err != nil {
+		log.Errorf("bridge shutdown: %v", err)
 	}
+	log.Info("bridge stopped")
 }

--- a/internal/app/health.go
+++ b/internal/app/health.go
@@ -17,12 +17,21 @@ type HealthChecker interface {
 
 // HealthManager manages the health status of the bridge
 type HealthManager struct {
-	healthy int64 // Use atomic for thread-safe access
+	healthy  int64 // storage reachability; updated by StartHealthMonitoring
+	draining int64 // 1 once SIGTERM shutdown has begun; flips /readyz to 503
 }
 
 // NewHealthManager creates a new health manager
 func NewHealthManager() *HealthManager {
 	return &HealthManager{healthy: 0}
+}
+
+// SetDraining marks the bridge as shutting down so ReadinessHandler starts returning 503, taking
+// the pod out of the load balancer rotation while it is still listening, before the HTTP server
+// actually stops accepting connections.
+func (h *HealthManager) SetDraining() {
+	atomic.StoreInt64(&h.draining, 1)
+	ReadyMetric.Set(0)
 }
 
 // UpdateHealthStatus checks storage health and updates metrics
@@ -69,6 +78,40 @@ func (h *HealthManager) HealthHandler(w http.ResponseWriter, r *http.Request) {
 	_, err := fmt.Fprintf(w, `{"status":"ok"}`+"\n")
 	if err != nil {
 		log.Errorf("health response write error: %v", err)
+	}
+}
+
+// LivenessHandler answers /healthz: it reports only that the PROCESS is alive and intentionally does
+// NOT check Valkey. Liveness drives the kubelet's restart decision, so coupling it to a shared
+// dependency would let one Valkey blip restart every replica at once (correlated eviction).
+func (h *HealthManager) LivenessHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("X-Build-Commit", internal.BridgeVersionRevision)
+	w.WriteHeader(http.StatusOK)
+	if _, err := fmt.Fprintf(w, `{"status":"ok"}`+"\n"); err != nil {
+		log.Errorf("liveness response write error: %v", err)
+	}
+}
+
+// ReadinessHandler answers /readyz, the load balancer health-check and readiness probe target. It
+// returns 503 once draining so the load balancer stops routing during shutdown, otherwise 200. It
+// is deliberately NOT Valkey-coupled: Valkey is shared by all replicas, so failing readiness on a
+// Valkey outage would take the whole pool out of rotation and 503 every request, whereas staying in
+// rotation lets the bridge return per-request errors that the client SDK retries. Storage health is
+// still exported via HealthMetric for alerting.
+func (h *HealthManager) ReadinessHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("X-Build-Commit", internal.BridgeVersionRevision)
+	if atomic.LoadInt64(&h.draining) != 0 {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		if _, err := fmt.Fprintf(w, `{"status":"draining"}`+"\n"); err != nil {
+			log.Errorf("readiness response write error: %v", err)
+		}
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+	if _, err := fmt.Fprintf(w, `{"status":"ok"}`+"\n"); err != nil {
+		log.Errorf("readiness response write error: %v", err)
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -14,6 +14,13 @@ var Config = struct {
 	Port         int    `env:"PORT" envDefault:"8081"`
 	MetricsPort  int    `env:"METRICS_PORT" envDefault:"9103"`
 	PprofEnabled bool   `env:"PPROF_ENABLED" envDefault:"true"`
+	// Graceful shutdown. On SIGTERM /readyz flips to 503 first; we keep serving for
+	// ShutdownDrainDelay so the load balancer health-check marks the instance unhealthy and stops
+	// routing before we stop accepting, then drain in-flight requests for up to ShutdownTimeout. SSE
+	// streams never complete on their own, so ShutdownTimeout caps how long we wait on them
+	// (clients reconnect). Both must sum below the pod terminationGracePeriodSeconds (40s).
+	ShutdownDrainDelay int `env:"SHUTDOWN_DRAIN_DELAY" envDefault:"15"`
+	ShutdownTimeout    int `env:"SHUTDOWN_TIMEOUT" envDefault:"10"`
 
 	// Storage
 	Storage   string `env:"STORAGE" envDefault:"memory"` // For v3 only: memory or valkey


### PR DESCRIPTION
The process had no signal handling, so on termination it exited immediately:
in-flight requests (including SSE) were dropped while new ones could still
arrive until the load balancer stopped routing. It now traps SIGTERM, marks
itself not-ready, waits a short configurable delay so the load balancer can
drain it, then shuts the HTTP server down within a bounded timeout. SSE streams
never end on their own, so that timeout caps the wait and clients reconnect.

Adds /healthz (liveness) and /readyz (readiness, 503 while shutting down) on the
metrics port. Both are independent of the storage backend, so a transient
storage error cannot restart or depool every replica at once.

Tunable via SHUTDOWN_DRAIN_DELAY and SHUTDOWN_TIMEOUT.
