### PR TITLE
Roll release pointer to 329a6b1

### DIFF
--- a/version.yaml
+++ b/version.yaml
@@ -2,4 +2,4 @@
 # Changes to this file intentionally do not trigger image builds.
 release:
   branch: master
-  sha: 7db5dce
+  sha: 329a6b1


### PR DESCRIPTION
Deploy the graceful-shutdown change: the published deployment now tracks 329a6b1 (drain on SIGTERM, /healthz and /readyz).