### PR TITLE
Roll release pointer to 46b5a98

### DIFF
--- a/version.yaml
+++ b/version.yaml
@@ -2,4 +2,4 @@
 # Changes to this file intentionally do not trigger image builds.
 release:
   branch: master
-  sha: 329a6b1
+  sha: 46b5a98


### PR DESCRIPTION
Deploy the v3 graceful-shutdown fix: the published deployment now tracks 46b5a98 (adds /healthz, /readyz and SIGTERM drain to the v3 entrypoint).