### PR TITLE
Point readiness at /readyz, liveness at /healthz

### DIFF
--- a/service.yaml
+++ b/service.yaml
@@ -8,7 +8,8 @@ resources:
   limits: { cpu: 500m, memory: 256Mi }
 healthcheck:
   port: 9103
-  readiness-path: /ready
-  liveness-path: /health
+  # readiness (and the LB health check) flips to 503 on drain so traffic stops; liveness stays 200.
+  readiness-path: /readyz
+  liveness-path: /healthz
 env:
   STORAGE: valkey


### PR DESCRIPTION
Moves the readiness probe and the load balancer health check on the admin port (9103) onto /readyz, which returns 503 during drain so traffic stops routing before the process exits. Liveness moves to /healthz, which stays 200 while the process is up. Both endpoints already ship in the deployed image (46b5a98, the v3 entrypoint) and were confirmed serving 200 on the live pods. Phase 2.