### PR TITLE
Track 592b4de (readiness on /readyz, liveness on /healthz)

### DIFF
--- a/version.yaml
+++ b/version.yaml
@@ -2,4 +2,4 @@
 # Changes to this file intentionally do not trigger image builds.
 release:
   branch: master
-  sha: 46b5a98
+  sha: 592b4de


### PR DESCRIPTION
Advances the release pointer to 592b4de (#227), moving the readiness probe and the load balancer health check on the admin port onto /readyz and liveness onto /healthz. Phase 2 cutover.