### PR TITLE
ci: skip the Go matrix for config-only changes

### DIFF
--- a/.github/workflows/basic.yaml
+++ b/.github/workflows/basic.yaml
@@ -1,10 +1,21 @@
 name: build
 
 on:
+  # Skip config-only changes: the deploy descriptor, release pointer and docs don't touch the
+  # Go binary, so there is nothing here to re-check. service.yaml still triggers an image build
+  # in build-image.yml, so every release-pointable commit stays deployable.
   push:
     branches: [ master ]
+    paths-ignore:
+      - 'service.yaml'
+      - 'version.yaml'
+      - '**/*.md'
   pull_request:
     branches: [ master ]
+    paths-ignore:
+      - 'service.yaml'
+      - 'version.yaml'
+      - '**/*.md'
 
 jobs:
   build:

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -4,8 +4,14 @@ name: Build image
 # Push-only triggers: the shared job mints short-lived cloud credentials via
 # OIDC, so it must never run for fork pull requests (no pull_request trigger).
 on:
+  # version.yaml only repoints the release to an already-built commit, and docs change nothing
+  # in the image, so neither needs a rebuild. service.yaml is intentionally NOT ignored: the
+  # appset reads it at the pointer commit, so that commit must have an image in the registry.
   push:
     branches: [master, 'release/**']
+    paths-ignore:
+      - 'version.yaml'
+      - '**/*.md'
 
 permissions:
   id-token: write

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -1,10 +1,22 @@
 name: codeql
 
 on:
+  # Skip config-only changes: the deploy descriptor, release pointer and docs don't touch the
+  # Go binary, so there is nothing here to analyze. service.yaml still triggers an image build
+  # in build-image.yml, so every release-pointable commit stays deployable. The scheduled scan
+  # below is unaffected and keeps covering the full tree.
   push:
     branches: [ master ]
+    paths-ignore:
+      - 'service.yaml'
+      - 'version.yaml'
+      - '**/*.md'
   pull_request:
     branches: [ master ]
+    paths-ignore:
+      - 'service.yaml'
+      - 'version.yaml'
+      - '**/*.md'
   schedule:
     - cron: '30 06 * * 6'
 

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,10 +1,21 @@
 name: lint
 
 on:
+  # Skip config-only changes: the deploy descriptor, release pointer and docs don't touch the
+  # Go binary, so there is nothing here to re-check. service.yaml still triggers an image build
+  # in build-image.yml, so every release-pointable commit stays deployable.
   push:
     branches: [ master ]
+    paths-ignore:
+      - 'service.yaml'
+      - 'version.yaml'
+      - '**/*.md'
   pull_request:
     branches: [ master ]
+    paths-ignore:
+      - 'service.yaml'
+      - 'version.yaml'
+      - '**/*.md'
 
 permissions:
   contents: read

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,10 +1,21 @@
 name: tests
 
 on:
+  # Skip config-only changes: the deploy descriptor, release pointer and docs don't touch the
+  # Go binary, so there is nothing here to re-check. service.yaml still triggers an image build
+  # in build-image.yml, so every release-pointable commit stays deployable.
   push:
     branches: [ master ]
+    paths-ignore:
+      - 'service.yaml'
+      - 'version.yaml'
+      - '**/*.md'
   pull_request:
     branches: [ master ]
+    paths-ignore:
+      - 'service.yaml'
+      - 'version.yaml'
+      - '**/*.md'
 
 
 jobs:


### PR DESCRIPTION
The deploy descriptor and release pointer (service.yaml, version.yaml) sit in the same repo as the Go source, so every edit to them used to fire the full CI: build, unit, golangci-lint, CodeQL and the integration plus metrics matrix across five storage backends. That matrix runs for around twenty minutes, and none of it re-checks anything when only a YAML descriptor moved, since the binary is identical. A recent /readyz health-check flip and its pointer bump each paid that full cost for a one-line change.

This adds paths-ignore (service.yaml, version.yaml, **/*.md) to the four Go workflows (tests, lint, codeql, build), so a change touching only those files skips the matrix. master has no required status checks, so a skipped run does not leave a PR stuck waiting on a check that never reports.

build-image.yml keeps building on service.yaml on purpose: the deploy reads service.yaml at the commit the release pointer names, so that commit must have an image in the registry, otherwise the next pointer bump would not be deployable. It now ignores version.yaml, which only repoints the release to an already-built commit and never needs a fresh image, finally making the version.yaml header comment (changes here do not trigger image builds) true. verify-release-pointer still runs on every PR and keeps validating that the pointer's image exists.

This workflow change itself is not config-only, so it runs the full matrix here, which is the intended behavior for any code or workflow edit.