### PR TITLE
logging: structured JSON access logs with msg + level

### DIFF
--- a/cmd/bridge/main.go
+++ b/cmd/bridge/main.go
@@ -88,8 +88,43 @@ func main() {
 		DisableStackAll:   true,
 		DisablePrintStack: false,
 	}))
-	//nolint:staticcheck // keep echo access-log middleware until a dedicated logging migration
-	e.Use(middleware.Logger())
+	// Structured access log via the modern RequestLogger API, emitted through logrus (JSON formatter
+	// set in config.LoadConfig) so every request line carries a `msg` and a status-derived `level`,
+	// consistent with the app logs. Replaces the deprecated middleware.Logger(), whose hardcoded JSON
+	// template had neither field.
+	e.Use(middleware.RequestLoggerWithConfig(middleware.RequestLoggerConfig{
+		LogMethod:    true,
+		LogURI:       true,
+		LogStatus:    true,
+		LogLatency:   true,
+		LogRemoteIP:  true,
+		LogHost:      true,
+		LogUserAgent: true,
+		LogError:     true,
+		LogValuesFunc: func(c echo.Context, v middleware.RequestLoggerValues) error {
+			entry := log.WithFields(log.Fields{
+				"method":     v.Method,
+				"uri":        v.URI,
+				"status":     v.Status,
+				"latency":    v.Latency.String(),
+				"remote_ip":  v.RemoteIP,
+				"host":       v.Host,
+				"user_agent": v.UserAgent,
+			})
+			if v.Error != nil {
+				entry = entry.WithField("error", v.Error.Error())
+			}
+			switch {
+			case v.Status >= 500:
+				entry.Error("http_request")
+			case v.Status >= 400:
+				entry.Warn("http_request")
+			default:
+				entry.Info("http_request")
+			}
+			return nil
+		},
+	}))
 	e.Use(middleware.RateLimiterWithConfig(middleware.RateLimiterConfig{
 		Skipper: func(c echo.Context) bool {
 			if app.SkipRateLimitsByToken(c.Request()) || c.Path() != "/bridge/message" {

--- a/cmd/bridge3/main.go
+++ b/cmd/bridge3/main.go
@@ -131,8 +131,43 @@ func main() {
 		DisableStackAll:   true,
 		DisablePrintStack: false,
 	}))
-	//nolint:staticcheck // keep echo access-log middleware until a dedicated logging migration
-	e.Use(middleware.Logger())
+	// Structured access log via the modern RequestLogger API, emitted through logrus (JSON formatter
+	// set in config.LoadConfig) so every request line carries a `msg` and a status-derived `level`,
+	// consistent with the app logs. Replaces the deprecated middleware.Logger(), whose hardcoded JSON
+	// template had neither field.
+	e.Use(middleware.RequestLoggerWithConfig(middleware.RequestLoggerConfig{
+		LogMethod:    true,
+		LogURI:       true,
+		LogStatus:    true,
+		LogLatency:   true,
+		LogRemoteIP:  true,
+		LogHost:      true,
+		LogUserAgent: true,
+		LogError:     true,
+		LogValuesFunc: func(c echo.Context, v middleware.RequestLoggerValues) error {
+			entry := log.WithFields(log.Fields{
+				"method":     v.Method,
+				"uri":        v.URI,
+				"status":     v.Status,
+				"latency":    v.Latency.String(),
+				"remote_ip":  v.RemoteIP,
+				"host":       v.Host,
+				"user_agent": v.UserAgent,
+			})
+			if v.Error != nil {
+				entry = entry.WithField("error", v.Error.Error())
+			}
+			switch {
+			case v.Status >= 500:
+				entry.Error("http_request")
+			case v.Status >= 400:
+				entry.Warn("http_request")
+			default:
+				entry.Info("http_request")
+			}
+			return nil
+		},
+	}))
 	e.Use(middleware.RateLimiterWithConfig(middleware.RateLimiterConfig{
 		Skipper: func(c echo.Context) bool {
 			if app.SkipRateLimitsByToken(c.Request()) || c.Path() != "/bridge/message" {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -87,4 +87,8 @@ func LoadConfig() {
 		level = logrus.InfoLevel
 	}
 	logrus.SetLevel(level)
+	// Emit structured JSON logs (logrus' default is plain key=value text). Gives every app log and
+	// the access log (cmd/*/main.go RequestLogger) a machine-parseable `level` + `msg`, so structured
+	// log backends ingest them natively instead of re-parsing text.
+	logrus.SetFormatter(&logrus.JSONFormatter{})
 }


### PR DESCRIPTION
## Problem

Two inconsistencies in the service's logs:

1. **Access logs** use the deprecated `echo` `middleware.Logger()`, whose hardcoded JSON template emits fields like `method`/`uri`/`status`/`latency` but **no `msg` and no `level`** — so access lines have no message or severity.
2. **App logs** go through `logrus` with its **default text formatter** (no `SetFormatter` anywhere), so they're plain `key=value` text while the access log is JSON — two different shapes.

Net: log lines are inconsistent and lack a machine-parseable `level`/`msg`, which makes them awkward to ingest/filter in any structured log backend.

## Change

- **`cmd/bridge3/main.go` + `cmd/bridge/main.go`**: replace `middleware.Logger()` with the modern, non-deprecated `middleware.RequestLoggerWithConfig` + `LogValuesFunc`, emitting each request through `logrus` with:
  - `msg: "http_request"`,
  - a **status-derived `level`** (`>=500` → error, `>=400` → warn, else info),
  - the same fields as before (method, uri, status, latency, remote_ip, host, user_agent, error).
  This also drops the `//nolint:staticcheck` (the deprecated API is gone).
- **`internal/config/config.go`**: set `logrus.SetFormatter(&logrus.JSONFormatter{})` so every app log **and** the access log is structured JSON with native `level` + `msg`.

## Notes
- No behavior change beyond log format. `LOG_LEVEL` still controls verbosity.
- `go build ./...`, `go vet`, `gofmt` clean.