### PR TITLE
release: bump bridge to bc97ab0 (structured JSON access logs)

### DIFF
--- a/version.yaml
+++ b/version.yaml
@@ -2,4 +2,4 @@
 # Changes to this file intentionally do not trigger image builds.
 release:
   branch: master
-  sha: 592b4de
+  sha: bc97ab0


### PR DESCRIPTION
Points the published deployment at `bc97ab0` (#230 — structured JSON access logs with `msg` + status-derived `level`).

Image already built to ECR by build.yml for this sha (build run: success). Pointer-only change, no code. Gated by verify-release-pointer (schema + provenance + ECR existence).