### PR TITLE
logging: migrate v3 and shared packages to log/slog

### DIFF
--- a/cmd/bridge/main.go
+++ b/cmd/bridge/main.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"net/http/pprof"
+	"os"
 	"os/signal"
 	"syscall"
 	"time"
@@ -20,6 +22,7 @@ import (
 	"github.com/ton-connect/bridge/internal/app"
 	"github.com/ton-connect/bridge/internal/config"
 	bridge_middleware "github.com/ton-connect/bridge/internal/middleware"
+	"github.com/ton-connect/bridge/internal/obs"
 	"github.com/ton-connect/bridge/internal/utils"
 	handlerv1 "github.com/ton-connect/bridge/internal/v1/handler"
 	"github.com/ton-connect/bridge/internal/v1/storage"
@@ -31,6 +34,7 @@ import (
 func main() {
 	log.Info(fmt.Sprintf("Bridge %s is running", internal.BridgeVersionRevision))
 	config.LoadConfig()
+	slog.SetDefault(obs.Setup(os.Stdout, config.Config.LogLevel, "bridge"))
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
 	defer stop()
 	app.InitMetrics()

--- a/cmd/bridge/main.go
+++ b/cmd/bridge/main.go
@@ -9,6 +9,7 @@ import (
 	"net/http/pprof"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 
@@ -31,10 +32,26 @@ import (
 	"golang.org/x/time/rate"
 )
 
+// configureV1Logrus configures the global logrus logger that the still-on-logrus v1 code uses: JSON
+// output at the configured level (an unknown level falls back to info). The v3 path logs through slog
+// (obs.Setup); this keeps v1's logrus output structured and consistent until the v1 code is migrated
+// off logrus. It lives here, in the v1 binary, so the shared config package stays logrus-free and the
+// v3 binary links without logrus.
+func configureV1Logrus() {
+	level, err := log.ParseLevel(strings.ToLower(config.Config.LogLevel))
+	if err != nil {
+		slog.Warn("invalid LOG_LEVEL, using default", "value", config.Config.LogLevel, "default", "info")
+		level = log.InfoLevel
+	}
+	log.SetLevel(level)
+	log.SetFormatter(&log.JSONFormatter{})
+}
+
 func main() {
 	log.Info(fmt.Sprintf("Bridge %s is running", internal.BridgeVersionRevision))
 	config.LoadConfig()
 	slog.SetDefault(obs.Setup(os.Stdout, config.Config.LogLevel, "bridge"))
+	configureV1Logrus()
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
 	defer stop()
 	app.InitMetrics()

--- a/cmd/bridge/main.go
+++ b/cmd/bridge/main.go
@@ -48,6 +48,9 @@ func configureV1Logrus() {
 }
 
 func main() {
+	// Install a JSON slog default before config loads so a config-parse failure logs on-contract
+	// (JSON + service/git_sha); reconfigure to the configured level once config is loaded.
+	slog.SetDefault(obs.Setup(os.Stdout, "info", "bridge"))
 	log.Info(fmt.Sprintf("Bridge %s is running", internal.BridgeVersionRevision))
 	config.LoadConfig()
 	slog.SetDefault(obs.Setup(os.Stdout, config.Config.LogLevel, "bridge"))

--- a/cmd/bridge3/main.go
+++ b/cmd/bridge3/main.go
@@ -32,9 +32,13 @@ import (
 )
 
 func main() {
+	// Install a JSON slog default before config loads so even a config-parse failure logs on-contract
+	// (JSON + service/git_sha), and emit the version banner first so a crash-looping pod still shows
+	// its revision. Reconfigure to the configured level once config is loaded.
+	slog.SetDefault(obs.Setup(os.Stdout, "info", "bridge"))
+	slog.Info("Bridge3 is running", "revision", internal.BridgeVersionRevision)
 	config.LoadConfig()
 	slog.SetDefault(obs.Setup(os.Stdout, config.Config.LogLevel, "bridge"))
-	slog.Info("Bridge3 is running", "revision", internal.BridgeVersionRevision)
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
 	defer stop()
 	app.InitMetrics()
@@ -164,7 +168,7 @@ func main() {
 				slog.String("user_agent", v.UserAgent),
 			}
 			if v.Error != nil {
-				attrs = append(attrs, slog.String("error", v.Error.Error()))
+				attrs = append(attrs, slog.String("err", v.Error.Error()))
 			}
 			slog.LogAttrs(c.Request().Context(), level, "http_request", attrs...)
 			return nil

--- a/cmd/bridge3/main.go
+++ b/cmd/bridge3/main.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"net/http/pprof"
+	"os"
 	"os/signal"
 	"syscall"
 	"time"
@@ -21,6 +23,7 @@ import (
 	"github.com/ton-connect/bridge/internal/config"
 	bridge_middleware "github.com/ton-connect/bridge/internal/middleware"
 	"github.com/ton-connect/bridge/internal/ntp"
+	"github.com/ton-connect/bridge/internal/obs"
 	"github.com/ton-connect/bridge/internal/utils"
 	handlerv3 "github.com/ton-connect/bridge/internal/v3/handler"
 	storagev3 "github.com/ton-connect/bridge/internal/v3/storage"
@@ -32,6 +35,7 @@ import (
 func main() {
 	log.Info(fmt.Sprintf("Bridge3 %s is running", internal.BridgeVersionRevision))
 	config.LoadConfig()
+	slog.SetDefault(obs.Setup(os.Stdout, config.Config.LogLevel, "bridge"))
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
 	defer stop()
 	app.InitMetrics()

--- a/cmd/bridge3/main.go
+++ b/cmd/bridge3/main.go
@@ -16,7 +16,6 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-	log "github.com/sirupsen/logrus"
 	"github.com/ton-connect/bridge/internal"
 	"github.com/ton-connect/bridge/internal/analytics"
 	"github.com/ton-connect/bridge/internal/app"
@@ -33,9 +32,9 @@ import (
 )
 
 func main() {
-	log.Info(fmt.Sprintf("Bridge3 %s is running", internal.BridgeVersionRevision))
 	config.LoadConfig()
 	slog.SetDefault(obs.Setup(os.Stdout, config.Config.LogLevel, "bridge"))
+	slog.Info("Bridge3 is running", "revision", internal.BridgeVersionRevision)
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
 	defer stop()
 	app.InitMetrics()
@@ -51,13 +50,10 @@ func main() {
 		ntpClient.Start(ctx)
 		defer ntpClient.Stop()
 		timeProvider = ntpClient
-		log.WithFields(log.Fields{
-			"servers":       config.Config.NTPServers,
-			"sync_interval": config.Config.NTPSyncInterval,
-		}).Info("NTP synchronization enabled")
+		slog.Info("NTP synchronization enabled", "servers", config.Config.NTPServers, "sync_interval", config.Config.NTPSyncInterval)
 	} else {
 		timeProvider = ntp.NewLocalTimeProvider()
-		log.Info("NTP synchronization disabled, using local time")
+		slog.Info("NTP synchronization disabled, using local time")
 	}
 	tonAnalytics := tonmetrics.NewAnalyticsClient()
 
@@ -69,13 +65,13 @@ func main() {
 
 	switch store {
 	case "postgres":
-		log.Info("Using PostgreSQL storage")
+		slog.Info("Using PostgreSQL storage")
 		dbURI = config.Config.PostgresURI
 	case "valkey":
-		log.Info("Using Valkey storage")
+		slog.Info("Using Valkey storage")
 		dbURI = config.Config.ValkeyURI
 	default:
-		log.Info("Using in-memory storage as default")
+		slog.Info("Using in-memory storage as default")
 		// No URI needed for memory storage
 	}
 
@@ -93,16 +89,17 @@ func main() {
 	dbConn, err := storagev3.NewStorage(store, dbURI, collector, analyticsBuilder)
 
 	if err != nil {
-		log.Fatalf("failed to create storage: %v", err)
+		slog.Error("failed to create storage", "err", err)
+		os.Exit(1)
 	}
 	if _, ok := dbConn.(*storagev3.MemStorage); ok {
-		log.Info("Using in-memory storage")
+		slog.Info("Using in-memory storage")
 		app.SetBridgeInfo("bridgev3", "memory")
 	} else if _, ok := dbConn.(*storagev3.ValkeyStorage); ok {
-		log.Info("Using Valkey/Redis storage")
+		slog.Info("Using Valkey/Redis storage")
 		app.SetBridgeInfo("bridgev3", "valkey")
 	} else {
-		log.Info("Using PostgreSQL storage")
+		slog.Info("Using PostgreSQL storage")
 		app.SetBridgeInfo("bridgev3", "postgres")
 	}
 	healthManager := app.NewHealthManager()
@@ -111,7 +108,7 @@ func main() {
 
 	extractor, err := utils.NewRealIPExtractor(config.Config.TrustedProxyRanges)
 	if err != nil {
-		log.Warnf("failed to create realIPExtractor: %v, using defaults", err)
+		slog.Warn("failed to create realIPExtractor, using defaults", "err", err)
 		extractor, _ = utils.NewRealIPExtractor([]string{})
 	}
 
@@ -126,7 +123,8 @@ func main() {
 		mux.HandleFunc("/debug/pprof/", pprof.Index)
 	}
 	go func() {
-		log.Fatal(http.ListenAndServe(fmt.Sprintf(":%d", config.Config.MetricsPort), mux))
+		slog.Error("metrics server failed", "err", http.ListenAndServe(fmt.Sprintf(":%d", config.Config.MetricsPort), mux))
+		os.Exit(1)
 	}()
 
 	e := echo.New()
@@ -135,8 +133,8 @@ func main() {
 		DisableStackAll:   true,
 		DisablePrintStack: false,
 	}))
-	// Structured access log via the modern RequestLogger API, emitted through logrus (JSON formatter
-	// set in config.LoadConfig) so every request line carries a `msg` and a status-derived `level`,
+	// Structured access log via the modern RequestLogger API, emitted through the default slog logger
+	// (JSON, configured in obs.Setup) so every request line carries a `msg` and a status-derived `level`,
 	// consistent with the app logs. Replaces the deprecated middleware.Logger(), whose hardcoded JSON
 	// template had neither field.
 	e.Use(middleware.RequestLoggerWithConfig(middleware.RequestLoggerConfig{
@@ -149,26 +147,26 @@ func main() {
 		LogUserAgent: true,
 		LogError:     true,
 		LogValuesFunc: func(c echo.Context, v middleware.RequestLoggerValues) error {
-			entry := log.WithFields(log.Fields{
-				"method":     v.Method,
-				"uri":        v.URI,
-				"status":     v.Status,
-				"latency":    v.Latency.String(),
-				"remote_ip":  v.RemoteIP,
-				"host":       v.Host,
-				"user_agent": v.UserAgent,
-			})
-			if v.Error != nil {
-				entry = entry.WithField("error", v.Error.Error())
-			}
+			level := slog.LevelInfo
 			switch {
 			case v.Status >= 500:
-				entry.Error("http_request")
+				level = slog.LevelError
 			case v.Status >= 400:
-				entry.Warn("http_request")
-			default:
-				entry.Info("http_request")
+				level = slog.LevelWarn
 			}
+			attrs := []slog.Attr{
+				slog.String("method", v.Method),
+				slog.String("uri", v.URI),
+				slog.Int("status", v.Status),
+				slog.String("latency", v.Latency.String()),
+				slog.String("remote_ip", v.RemoteIP),
+				slog.String("host", v.Host),
+				slog.String("user_agent", v.UserAgent),
+			}
+			if v.Error != nil {
+				attrs = append(attrs, slog.String("error", v.Error.Error()))
+			}
+			slog.LogAttrs(c.Request().Context(), level, "http_request", attrs...)
 			return nil
 		},
 	}))
@@ -218,7 +216,8 @@ func main() {
 		if config.Config.SelfSignedTLS {
 			cert, key, certErr := utils.GenerateSelfSignedCertificate()
 			if certErr != nil {
-				log.Fatalf("failed to generate self signed certificate: %v", certErr)
+				slog.Error("failed to generate self signed certificate", "err", certErr)
+				os.Exit(1)
 			}
 			err = e.StartTLS(fmt.Sprintf(":%v", config.Config.Port), cert, key)
 		} else {
@@ -226,7 +225,8 @@ func main() {
 		}
 		// Shutdown closes the listener and returns ErrServerClosed, the normal stop path.
 		if err != nil && !errors.Is(err, http.ErrServerClosed) {
-			log.Fatalf("bridge server: %v", err)
+			slog.Error("bridge server failed", "err", err)
+			os.Exit(1)
 		}
 	}()
 
@@ -234,13 +234,13 @@ func main() {
 	// Graceful shutdown: flip /readyz to 503 so the load balancer takes the pod out of rotation
 	// while it is still listening, wait the drain window, then drain in-flight requests. SSE streams
 	// never complete on their own, so the bounded ShutdownTimeout ends the wait (clients reconnect).
-	log.Info("SIGTERM received, draining")
+	slog.Info("SIGTERM received, draining")
 	healthManager.SetDraining()
 	time.Sleep(time.Duration(config.Config.ShutdownDrainDelay) * time.Second)
 	shutdownCtx, cancel := context.WithTimeout(context.Background(), time.Duration(config.Config.ShutdownTimeout)*time.Second)
 	defer cancel()
 	if err := e.Shutdown(shutdownCtx); err != nil {
-		log.Errorf("bridge shutdown: %v", err)
+		slog.Error("bridge shutdown", "err", err)
 	}
-	log.Info("bridge stopped")
+	slog.Info("bridge stopped")
 }

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/realclientip/realclientip-go v1.0.0
 	github.com/redis/go-redis/v9 v9.20.0
 	github.com/sirupsen/logrus v1.9.4
+	github.com/stretchr/testify v1.11.1
 	golang.org/x/crypto v0.52.0
 	golang.org/x/exp v0.0.0-20230626212559-97b1e661b5df
 	golang.org/x/time v0.15.0
@@ -22,6 +23,7 @@ require (
 require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
+	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/jackc/chunkreader/v2 v2.0.1 // indirect
 	github.com/jackc/pgconn v1.14.3 // indirect
 	github.com/jackc/pgio v1.0.0 // indirect
@@ -35,6 +37,7 @@ require (
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.22 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.67.5 // indirect
 	github.com/prometheus/procfs v0.19.2 // indirect
@@ -46,4 +49,5 @@ require (
 	golang.org/x/sys v0.45.0 // indirect
 	golang.org/x/text v0.37.0 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/internal/analytics/collector.go
+++ b/internal/analytics/collector.go
@@ -2,10 +2,10 @@ package analytics
 
 import (
 	"context"
+	"log/slog"
 	"sync/atomic"
 	"time"
 
-	"github.com/sirupsen/logrus"
 	"github.com/ton-connect/bridge/tonmetrics"
 )
 
@@ -115,25 +115,25 @@ func (c *Collector) Run(ctx context.Context) {
 	flushTicker := time.NewTicker(c.flushInterval)
 	defer flushTicker.Stop()
 
-	logrus.WithField("prefix", "analytics").Debugf("analytics collector started with flush interval %v", c.flushInterval)
+	slog.With("prefix", "analytics").Debug("analytics collector started", "flush_interval", c.flushInterval)
 
 	for {
 		select {
 		case <-ctx.Done():
-			logrus.WithField("prefix", "analytics").Debug("analytics collector stopping, performing final flush")
+			slog.With("prefix", "analytics").Debug("analytics collector stopping, performing final flush")
 			// Use fresh context for final flush since ctx is already cancelled
 			flushCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			c.Flush(flushCtx)
 			cancel()
-			logrus.WithField("prefix", "analytics").Debug("analytics collector stopped")
+			slog.With("prefix", "analytics").Debug("analytics collector stopped")
 			return
 		case <-flushTicker.C:
 			if c.Len() > 0 {
-				logrus.WithField("prefix", "analytics").Debug("analytics collector ticker fired")
+				slog.With("prefix", "analytics").Debug("analytics collector ticker fired")
 				c.Flush(ctx)
 			}
 		case <-c.notifyCh:
-			logrus.WithField("prefix", "analytics").Debugf("analytics collector buffer reached %d events, flushing", c.Len())
+			slog.With("prefix", "analytics").Debug("analytics collector buffer reached trigger, flushing", "count", c.Len())
 			c.Flush(ctx)
 		}
 	}
@@ -142,9 +142,9 @@ func (c *Collector) Run(ctx context.Context) {
 func (c *Collector) Flush(ctx context.Context) {
 	events := c.PopAll()
 	if len(events) > 0 {
-		logrus.WithField("prefix", "analytics").Debugf("flushing %d events from collector", len(events))
+		slog.With("prefix", "analytics").Debug("flushing events from collector", "count", len(events))
 		if err := c.sender.SendBatch(ctx, events); err != nil {
-			logrus.WithError(err).Warnf("analytics: failed to send batch of %d events", len(events))
+			slog.Warn("analytics: failed to send batch", "count", len(events), "err", err)
 		}
 	}
 }

--- a/internal/analytics/collector.go
+++ b/internal/analytics/collector.go
@@ -29,6 +29,10 @@ type Collector struct {
 	// Sender fields
 	sender        tonmetrics.AnalyticsClient
 	flushInterval time.Duration
+
+	// logger carries the constant prefix=analytics attr; built once so the hot Run loop does not
+	// re-derive it per ticker fire.
+	logger *slog.Logger
 }
 
 // NewCollector builds a collector with a periodic flush.
@@ -44,6 +48,7 @@ func NewCollector(capacity int, client tonmetrics.AnalyticsClient, flushInterval
 		triggerCapacity: triggerCapacity,
 		sender:          client,
 		flushInterval:   flushInterval,
+		logger:          slog.With("prefix", "analytics"),
 	}
 }
 
@@ -115,25 +120,25 @@ func (c *Collector) Run(ctx context.Context) {
 	flushTicker := time.NewTicker(c.flushInterval)
 	defer flushTicker.Stop()
 
-	slog.With("prefix", "analytics").Debug("analytics collector started", "flush_interval", c.flushInterval)
+	c.logger.Debug("analytics collector started", "flush_interval", c.flushInterval)
 
 	for {
 		select {
 		case <-ctx.Done():
-			slog.With("prefix", "analytics").Debug("analytics collector stopping, performing final flush")
+			c.logger.Debug("analytics collector stopping, performing final flush")
 			// Use fresh context for final flush since ctx is already cancelled
 			flushCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			c.Flush(flushCtx)
 			cancel()
-			slog.With("prefix", "analytics").Debug("analytics collector stopped")
+			c.logger.Debug("analytics collector stopped")
 			return
 		case <-flushTicker.C:
 			if c.Len() > 0 {
-				slog.With("prefix", "analytics").Debug("analytics collector ticker fired")
+				c.logger.Debug("analytics collector ticker fired")
 				c.Flush(ctx)
 			}
 		case <-c.notifyCh:
-			slog.With("prefix", "analytics").Debug("analytics collector buffer reached trigger, flushing", "count", c.Len())
+			c.logger.Debug("analytics collector buffer reached trigger, flushing", "count", c.Len())
 			c.Flush(ctx)
 		}
 	}
@@ -142,9 +147,9 @@ func (c *Collector) Run(ctx context.Context) {
 func (c *Collector) Flush(ctx context.Context) {
 	events := c.PopAll()
 	if len(events) > 0 {
-		slog.With("prefix", "analytics").Debug("flushing events from collector", "count", len(events))
+		c.logger.Debug("flushing events from collector", "count", len(events))
 		if err := c.sender.SendBatch(ctx, events); err != nil {
-			slog.Warn("analytics: failed to send batch", "count", len(events), "err", err)
+			c.logger.Warn("failed to send batch", "count", len(events), "err", err)
 		}
 	}
 }

--- a/internal/analytics/event.go
+++ b/internal/analytics/event.go
@@ -2,10 +2,10 @@ package analytics
 
 import (
 	"fmt"
+	"log/slog"
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/sirupsen/logrus"
 	"github.com/ton-connect/bridge/tonmetrics"
 )
 
@@ -241,7 +241,7 @@ func optionalString(value string) *string {
 func newAnalyticsEventID() *string {
 	id, err := uuid.NewV7()
 	if err != nil {
-		logrus.WithError(err).Warn("Failed to generate UUIDv7, falling back to UUIDv4")
+		slog.Warn("Failed to generate UUIDv7, falling back to UUIDv4", "err", err)
 		str := uuid.New().String()
 		return &str
 	}

--- a/internal/app/health.go
+++ b/internal/app/health.go
@@ -2,11 +2,11 @@ package app
 
 import (
 	"fmt"
+	"log/slog"
 	"net/http"
 	"sync/atomic"
 	"time"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/ton-connect/bridge/internal"
 )
 
@@ -69,7 +69,7 @@ func (h *HealthManager) HealthHandler(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusServiceUnavailable)
 		_, err := fmt.Fprintf(w, `{"status":"unhealthy"}`+"\n")
 		if err != nil {
-			log.Errorf("health response write error: %v", err)
+			slog.Error("health response write error", "err", err)
 		}
 		return
 	}
@@ -77,7 +77,7 @@ func (h *HealthManager) HealthHandler(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 	_, err := fmt.Fprintf(w, `{"status":"ok"}`+"\n")
 	if err != nil {
-		log.Errorf("health response write error: %v", err)
+		slog.Error("health response write error", "err", err)
 	}
 }
 
@@ -89,7 +89,7 @@ func (h *HealthManager) LivenessHandler(w http.ResponseWriter, r *http.Request) 
 	w.Header().Set("X-Build-Commit", internal.BridgeVersionRevision)
 	w.WriteHeader(http.StatusOK)
 	if _, err := fmt.Fprintf(w, `{"status":"ok"}`+"\n"); err != nil {
-		log.Errorf("liveness response write error: %v", err)
+		slog.Error("liveness response write error", "err", err)
 	}
 }
 
@@ -105,13 +105,13 @@ func (h *HealthManager) ReadinessHandler(w http.ResponseWriter, r *http.Request)
 	if atomic.LoadInt64(&h.draining) != 0 {
 		w.WriteHeader(http.StatusServiceUnavailable)
 		if _, err := fmt.Fprintf(w, `{"status":"draining"}`+"\n"); err != nil {
-			log.Errorf("readiness response write error: %v", err)
+			slog.Error("readiness response write error", "err", err)
 		}
 		return
 	}
 	w.WriteHeader(http.StatusOK)
 	if _, err := fmt.Fprintf(w, `{"status":"ok"}`+"\n"); err != nil {
-		log.Errorf("readiness response write error: %v", err)
+		slog.Error("readiness response write error", "err", err)
 	}
 }
 
@@ -124,6 +124,6 @@ func VersionHandler(w http.ResponseWriter, r *http.Request) {
 	response := fmt.Sprintf(`{"version":"%s"}`, internal.BridgeVersionRevision)
 	_, err := fmt.Fprintf(w, "%s", response+"\n")
 	if err != nil {
-		log.Errorf("version response write error: %v", err)
+		slog.Error("version response write error", "err", err)
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,10 +3,8 @@ package config
 import (
 	"log/slog"
 	"os"
-	"strings"
 
 	"github.com/caarlos0/env/v6"
-	"github.com/sirupsen/logrus"
 )
 
 var Config = struct {
@@ -77,20 +75,12 @@ var Config = struct {
 	TonAnalyticsNetworkId     string `env:"TON_ANALYTICS_NETWORK_ID" envDefault:"-239"`
 }{}
 
+// LoadConfig parses the process environment into Config. Logger configuration is no longer done here:
+// the v3 binary configures slog via obs.Setup, and the v1 binary configures logrus via configureV1Logrus
+// in cmd/bridge. Keeping this package logrus-free is what lets the v3 binary link without logrus.
 func LoadConfig() {
 	if err := env.Parse(&Config); err != nil {
 		slog.Error("config parsing failed", "err", err)
 		os.Exit(1)
 	}
-
-	level, err := logrus.ParseLevel(strings.ToLower(Config.LogLevel))
-	if err != nil {
-		slog.Warn("invalid LOG_LEVEL, using default", "value", Config.LogLevel, "default", "info")
-		level = logrus.InfoLevel
-	}
-	logrus.SetLevel(level)
-	// Emit structured JSON logs (logrus' default is plain key=value text). Gives every app log and
-	// the access log (cmd/*/main.go RequestLogger) a machine-parseable `level` + `msg`, so structured
-	// log backends ingest them natively instead of re-parsing text.
-	logrus.SetFormatter(&logrus.JSONFormatter{})
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,7 +1,8 @@
 package config
 
 import (
-	"log"
+	"log/slog"
+	"os"
 	"strings"
 
 	"github.com/caarlos0/env/v6"
@@ -78,12 +79,13 @@ var Config = struct {
 
 func LoadConfig() {
 	if err := env.Parse(&Config); err != nil {
-		log.Fatalf("config parsing failed: %v\n", err)
+		slog.Error("config parsing failed", "err", err)
+		os.Exit(1)
 	}
 
 	level, err := logrus.ParseLevel(strings.ToLower(Config.LogLevel))
 	if err != nil {
-		log.Printf("Invalid LOG_LEVEL '%s', using default 'info'. Valid levels: panic, fatal, error, warn, info, debug, trace", Config.LogLevel)
+		slog.Warn("invalid LOG_LEVEL, using default", "value", Config.LogLevel, "default", "info")
 		level = logrus.InfoLevel
 	}
 	logrus.SetLevel(level)

--- a/internal/handler/trace.go
+++ b/internal/handler/trace.go
@@ -12,7 +12,7 @@ func ParseOrGenerateTraceID(traceIdParam string, ok bool) string {
 	if ok {
 		uuids, err := uuid.Parse(traceIdParam)
 		if err != nil {
-			logger.Warn("generating a new trace_id", "error", err, "invalid_trace_id", traceIdParam[0])
+			logger.Warn("generating a new trace_id", "err", err, "invalid_trace_id", traceIdParam)
 		} else {
 			traceId = uuids.String()
 		}

--- a/internal/handler/trace.go
+++ b/internal/handler/trace.go
@@ -1,20 +1,18 @@
 package handler
 
 import (
+	"log/slog"
+
 	"github.com/google/uuid"
-	"github.com/sirupsen/logrus"
 )
 
 func ParseOrGenerateTraceID(traceIdParam string, ok bool) string {
-	log := logrus.WithField("prefix", "CreateSession")
+	logger := slog.With("prefix", "CreateSession")
 	traceId := "unknown"
 	if ok {
 		uuids, err := uuid.Parse(traceIdParam)
 		if err != nil {
-			log.WithFields(logrus.Fields{
-				"error":            err,
-				"invalid_trace_id": traceIdParam[0],
-			}).Warn("generating a new trace_id")
+			logger.Warn("generating a new trace_id", "error", err, "invalid_trace_id", traceIdParam[0])
 		} else {
 			traceId = uuids.String()
 		}
@@ -22,7 +20,7 @@ func ParseOrGenerateTraceID(traceIdParam string, ok bool) string {
 	if traceId == "unknown" {
 		uuids, err := uuid.NewV7()
 		if err != nil {
-			log.Error(err)
+			logger.Error("failed to generate trace_id", "err", err)
 		} else {
 			traceId = uuids.String()
 		}

--- a/internal/handler/webhook.go
+++ b/internal/handler/webhook.go
@@ -4,10 +4,10 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"strings"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/ton-connect/bridge/internal/config"
 )
 
@@ -25,7 +25,7 @@ func SendWebhook(clientID string, body WebhookData) {
 		go func(webhook string) {
 			err := sendWebhook(clientID, body, webhook)
 			if err != nil {
-				log.Errorf("failed to trigger webhook '%s': %v", webhook, err)
+				slog.Error("failed to trigger webhook", "webhook", webhook, "err", err)
 			}
 		}(webhook)
 	}
@@ -47,7 +47,7 @@ func sendWebhook(clientID string, body WebhookData, webhook string) error {
 	}
 	defer func() {
 		if closeErr := res.Body.Close(); closeErr != nil {
-			log.Errorf("failed to close response body: %v", closeErr)
+			slog.Error("failed to close response body", "err", closeErr)
 		}
 	}()
 	if res.StatusCode != http.StatusOK {

--- a/internal/ntp/client.go
+++ b/internal/ntp/client.go
@@ -110,12 +110,12 @@ func (c *Client) trySyncWithServer(server string) bool {
 
 	response, err := ntp.QueryWithOptions(server, options)
 	if err != nil {
-		slog.Debug("Failed to query NTP server", "server", server, "error", err)
+		slog.Debug("Failed to query NTP server", "server", server, "err", err)
 		return false
 	}
 
 	if err := response.Validate(); err != nil {
-		slog.Debug("Invalid response from NTP server", "server", server, "error", err)
+		slog.Debug("Invalid response from NTP server", "server", server, "err", err)
 		return false
 	}
 

--- a/internal/ntp/client.go
+++ b/internal/ntp/client.go
@@ -5,8 +5,9 @@ import (
 	"sync/atomic"
 	"time"
 
+	"log/slog"
+
 	"github.com/beevik/ntp"
-	"github.com/sirupsen/logrus"
 )
 
 type Client struct {
@@ -54,14 +55,11 @@ func NewClient(opts Options) *Client {
 
 func (c *Client) Start(ctx context.Context) {
 	if !c.stopped.CompareAndSwap(true, false) {
-		logrus.Warn("NTP client already started")
+		slog.Warn("NTP client already started")
 		return
 	}
 
-	logrus.WithFields(logrus.Fields{
-		"servers":       c.servers,
-		"sync_interval": c.syncInterval,
-	}).Info("Starting NTP client")
+	slog.Info("Starting NTP client", "servers", c.servers, "sync_interval", c.syncInterval)
 
 	c.syncOnce()
 
@@ -73,7 +71,7 @@ func (c *Client) Stop() {
 		return
 	}
 	close(c.stopCh)
-	logrus.Info("NTP client stopped")
+	slog.Info("NTP client stopped")
 }
 
 func (c *Client) syncLoop(ctx context.Context) {
@@ -99,7 +97,7 @@ func (c *Client) syncOnce() {
 		}
 	}
 
-	logrus.Warn("Failed to synchronize with any NTP server, using local time")
+	slog.Warn("Failed to synchronize with any NTP server, using local time")
 }
 
 func (c *Client) trySyncWithServer(server string) bool {
@@ -112,30 +110,19 @@ func (c *Client) trySyncWithServer(server string) bool {
 
 	response, err := ntp.QueryWithOptions(server, options)
 	if err != nil {
-		logrus.WithFields(logrus.Fields{
-			"server": server,
-			"error":  err,
-		}).Debug("Failed to query NTP server")
+		slog.Debug("Failed to query NTP server", "server", server, "error", err)
 		return false
 	}
 
 	if err := response.Validate(); err != nil {
-		logrus.WithFields(logrus.Fields{
-			"server": server,
-			"error":  err,
-		}).Debug("Invalid response from NTP server")
+		slog.Debug("Invalid response from NTP server", "server", server, "error", err)
 		return false
 	}
 
 	c.offset.Store(int64(response.ClockOffset))
 	c.lastSync.Store(time.Now().Unix())
 
-	logrus.WithFields(logrus.Fields{
-		"server":    server,
-		"offset":    response.ClockOffset,
-		"precision": response.RTT / 2,
-		"rtt":       response.RTT,
-	}).Info("Successfully synchronized with NTP server")
+	slog.Info("Successfully synchronized with NTP server", "server", server, "offset", response.ClockOffset, "precision", response.RTT/2, "rtt", response.RTT)
 
 	select {
 	case <-ctx.Done():

--- a/internal/obs/obs.go
+++ b/internal/obs/obs.go
@@ -1,0 +1,44 @@
+// Package obs is the bridge observability contract: a JSON slog on stdout with
+// constant service + git_sha attributes, installed as the slog default in each
+// binary's main. During the v1→v3 logging transition the v3 path logs through
+// this; v1-specific code still uses logrus (configured in internal/config).
+package obs
+
+import (
+	"io"
+	"log/slog"
+	"os"
+	"runtime/debug"
+	"strings"
+)
+
+// Setup builds the root JSON logger on w, filtered at level (unknown → info),
+// tagged with constant service + git_sha attributes.
+func Setup(w io.Writer, level, service string) *slog.Logger {
+	var l slog.Level
+	switch strings.ToLower(level) {
+	case "debug", "trace":
+		l = slog.LevelDebug
+	case "warn", "warning":
+		l = slog.LevelWarn
+	case "error", "fatal", "panic":
+		l = slog.LevelError
+	default:
+		l = slog.LevelInfo
+	}
+	h := slog.NewJSONHandler(w, &slog.HandlerOptions{Level: l})
+	return slog.New(h).With(slog.String("service", service), slog.String("git_sha", gitSHAShort()))
+}
+
+// gitSHAShort returns the short VCS revision the binary was built from (build-info
+// stamp), falling back to GIT_SHA_SHORT when there is no stamp (e.g. `go run`).
+func gitSHAShort() string {
+	if bi, ok := debug.ReadBuildInfo(); ok {
+		for _, s := range bi.Settings {
+			if s.Key == "vcs.revision" && s.Value != "" {
+				return s.Value[:min(7, len(s.Value))]
+			}
+		}
+	}
+	return os.Getenv("GIT_SHA_SHORT")
+}

--- a/internal/obs/obs.go
+++ b/internal/obs/obs.go
@@ -7,38 +7,44 @@ package obs
 import (
 	"io"
 	"log/slog"
-	"os"
-	"runtime/debug"
 	"strings"
+
+	"github.com/ton-connect/bridge/internal"
 )
 
-// Setup builds the root JSON logger on w, filtered at level (unknown → info),
-// tagged with constant service + git_sha attributes.
+// Setup builds the root JSON logger on w, filtered at level, tagged with constant
+// service + git_sha attributes. An unrecognized level falls back to info and the
+// returned logger emits a warning, so a misconfigured LOG_LEVEL is not silent.
 func Setup(w io.Writer, level, service string) *slog.Logger {
-	var l slog.Level
-	switch strings.ToLower(level) {
-	case "debug", "trace":
-		l = slog.LevelDebug
-	case "warn", "warning":
-		l = slog.LevelWarn
-	case "error", "fatal", "panic":
-		l = slog.LevelError
-	default:
-		l = slog.LevelInfo
-	}
+	l, ok := parseLevel(level)
 	h := slog.NewJSONHandler(w, &slog.HandlerOptions{Level: l})
-	return slog.New(h).With(slog.String("service", service), slog.String("git_sha", gitSHAShort()))
+	logger := slog.New(h).With(slog.String("service", service), slog.String("git_sha", gitSHAShort()))
+	if !ok {
+		logger.Warn("unrecognized LOG_LEVEL, using info", "value", level)
+	}
+	return logger
 }
 
-// gitSHAShort returns the short VCS revision the binary was built from (build-info
-// stamp), falling back to GIT_SHA_SHORT when there is no stamp (e.g. `go run`).
-func gitSHAShort() string {
-	if bi, ok := debug.ReadBuildInfo(); ok {
-		for _, s := range bi.Settings {
-			if s.Key == "vcs.revision" && s.Value != "" {
-				return s.Value[:min(7, len(s.Value))]
-			}
-		}
+// parseLevel maps a textual level to a slog.Level. ok is false when level is not a
+// recognized name, in which case the caller falls back to info and warns.
+func parseLevel(level string) (slog.Level, bool) {
+	switch strings.ToLower(level) {
+	case "debug", "trace":
+		return slog.LevelDebug, true
+	case "", "info":
+		return slog.LevelInfo, true
+	case "warn", "warning":
+		return slog.LevelWarn, true
+	case "error", "fatal", "panic":
+		return slog.LevelError, true
+	default:
+		return slog.LevelInfo, false
 	}
-	return os.Getenv("GIT_SHA_SHORT")
+}
+
+// gitSHAShort returns the git revision the binary was built from, for the git_sha
+// log attribute. It uses internal.GitRevision, injected at build time via -X ldflags
+// (see Makefile); in un-injected builds (go run, tests) it is the "devel" default.
+func gitSHAShort() string {
+	return internal.GitRevision
 }

--- a/internal/obs/obs_test.go
+++ b/internal/obs/obs_test.go
@@ -27,6 +27,9 @@ func TestSetupEmitsJSONWithServiceAndGitSHA(t *testing.T) {
 func TestSetupUnknownLevelFallsBackToInfo(t *testing.T) {
 	var buf bytes.Buffer
 	logger := obs.Setup(&buf, "bogus", "bridge")
+	// An unrecognized level emits a warning through the returned logger, then falls back to info.
+	require.Contains(t, buf.String(), "unrecognized LOG_LEVEL")
+	buf.Reset()
 	logger.Debug("suppressed")
 	require.Empty(t, buf.String())
 	logger.Info("kept")

--- a/internal/obs/obs_test.go
+++ b/internal/obs/obs_test.go
@@ -1,0 +1,34 @@
+package obs_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/ton-connect/bridge/internal/obs"
+)
+
+func TestSetupEmitsJSONWithServiceAndGitSHA(t *testing.T) {
+	var buf bytes.Buffer
+	logger := obs.Setup(&buf, "info", "bridge")
+	logger.Info("hello", "k", "v")
+
+	var rec map[string]any
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &rec))
+	require.Equal(t, "INFO", rec["level"])
+	require.Equal(t, "hello", rec["msg"])
+	require.Equal(t, "bridge", rec["service"])
+	require.Equal(t, "v", rec["k"])
+	_, ok := rec["git_sha"]
+	require.True(t, ok)
+}
+
+func TestSetupUnknownLevelFallsBackToInfo(t *testing.T) {
+	var buf bytes.Buffer
+	logger := obs.Setup(&buf, "bogus", "bridge")
+	logger.Debug("suppressed")
+	require.Empty(t, buf.String())
+	logger.Info("kept")
+	require.Contains(t, buf.String(), `"msg":"kept"`)
+}

--- a/internal/v3/handler/handler.go
+++ b/internal/v3/handler/handler.go
@@ -387,7 +387,7 @@ func (h *handler) SendMessageHandler(c echo.Context) error {
 
 	// Send message only to storage - pub-sub will handle distribution
 	go func() {
-		logger := logger.With("prefix", "SendMessageHandler.storage.Pub")
+		logger := slog.With("prefix", "SendMessageHandler.storage.Pub")
 		err = h.storage.Pub(context.Background(), sseMessage, ttl)
 		if err != nil {
 			// TODO ooops

--- a/internal/v3/handler/handler.go
+++ b/internal/v3/handler/handler.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"math/rand"
 	"net/http"
 	"net/url"
@@ -19,7 +20,6 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
-	"github.com/sirupsen/logrus"
 	"github.com/ton-connect/bridge/internal/analytics"
 	"github.com/ton-connect/bridge/internal/config"
 	handler_common "github.com/ton-connect/bridge/internal/handler"
@@ -92,7 +92,7 @@ func NewHandler(s storagev3.Storage, heartbeatInterval time.Duration, extractor 
 }
 
 func (h *handler) EventRegistrationHandler(c echo.Context) error {
-	log := logrus.WithField("prefix", "EventRegistrationHandler")
+	logger := slog.With("prefix", "EventRegistrationHandler")
 	_, ok := c.Response().Writer.(http.Flusher)
 	if !ok {
 		http.Error(c.Response().Writer, "streaming unsupported", http.StatusInternalServerError)
@@ -105,7 +105,7 @@ func (h *handler) EventRegistrationHandler(c echo.Context) error {
 	c.Response().Header().Set("X-Accel-Buffering", "no")
 	c.Response().WriteHeader(http.StatusOK)
 	if _, err := fmt.Fprint(c.Response(), "\n"); err != nil {
-		log.Errorf("failed to write initial newline: %v", err)
+		logger.Error("failed to write initial newline", "err", err)
 		return err
 	}
 	c.Response().Flush()
@@ -127,7 +127,7 @@ func (h *handler) EventRegistrationHandler(c echo.Context) error {
 	if !ok {
 		badRequestMetric.Inc()
 		errorMsg := "invalid heartbeat type. Supported: legacy and message"
-		log.Error(errorMsg)
+		logger.Error(errorMsg)
 		h.logEventRegistrationValidationFailure("", traceId, "events/heartbeat")
 		return c.JSON(utils.HttpResError(errorMsg, http.StatusBadRequest))
 	}
@@ -140,7 +140,7 @@ func (h *handler) EventRegistrationHandler(c echo.Context) error {
 		if err != nil {
 			badRequestMetric.Inc()
 			errorMsg := "Last-Event-ID should be int"
-			log.Error(errorMsg)
+			logger.Error(errorMsg)
 			h.logEventRegistrationValidationFailure("", traceId, "events/last-event-id-header")
 			return c.JSON(utils.HttpResError(errorMsg, http.StatusBadRequest))
 		}
@@ -151,7 +151,7 @@ func (h *handler) EventRegistrationHandler(c echo.Context) error {
 		if err != nil {
 			badRequestMetric.Inc()
 			errorMsg := "last_event_id should be int"
-			log.Error(errorMsg)
+			logger.Error(errorMsg)
 			h.logEventRegistrationValidationFailure("", traceId, "events/last-event-id-query")
 			return c.JSON(utils.HttpResError(errorMsg, http.StatusBadRequest))
 		}
@@ -160,7 +160,7 @@ func (h *handler) EventRegistrationHandler(c echo.Context) error {
 	if !ok {
 		badRequestMetric.Inc()
 		errorMsg := "param \"client_id\" not present"
-		log.Error(errorMsg)
+		logger.Error(errorMsg)
 		h.logEventRegistrationValidationFailure("", traceId, "events/missing-client-id")
 		return c.JSON(utils.HttpResError(errorMsg, http.StatusBadRequest))
 	}
@@ -170,7 +170,7 @@ func (h *handler) EventRegistrationHandler(c echo.Context) error {
 		if _, err := utils.NewPublicAddressFromString(id); err != nil {
 			badRequestMetric.Inc()
 			errMsg := fmt.Errorf("param \"client_id\" must be a valid public address, error: %w", err).Error()
-			log.Error(errMsg)
+			logger.Error(errMsg)
 			h.logEventRegistrationValidationFailure("", traceId, errMsg)
 			return c.JSON(utils.HttpResError(errMsg, http.StatusBadRequest))
 		}
@@ -194,7 +194,7 @@ func (h *handler) EventRegistrationHandler(c echo.Context) error {
 
 		ttl := time.Duration(config.Config.ConnectCacheTTL) * time.Second
 		if err := h.storage.AddConnection(c.Request().Context(), conn, ttl); err != nil {
-			log.Warnf("failed to store connection: %v", err)
+			logger.Warn("failed to store connection", "err", err)
 		}
 	}
 
@@ -204,14 +204,14 @@ func (h *handler) EventRegistrationHandler(c echo.Context) error {
 		<-notify
 		session.Close()
 		h.removeConnection(session, traceId)
-		log.Infof("connection: %v closed with error %v", session.ClientIds, ctx.Err())
+		logger.Info("connection closed with error", "client_ids", session.ClientIds, "err", ctx.Err())
 	}()
 
 	// Force-close the session after max lifetime. This runs outside the select loop
 	// so it works even when messages are flowing continuously.
 	maxLifetime := sseMaxLifetimeWithJitter()
 	lifetimeTimer := time.AfterFunc(maxLifetime, func() {
-		log.Infof("SSE connection max lifetime reached (%v), closing", maxLifetime)
+		logger.Info("SSE connection max lifetime reached, closing", "max_lifetime", maxLifetime)
 		session.Close()
 	})
 	defer lifetimeTimer.Stop()
@@ -230,7 +230,7 @@ loop:
 			}
 			_, err = fmt.Fprintf(c.Response(), "event: %v\nid: %v\ndata: %v\n\n", "message", msg.EventId, string(msg.Message))
 			if err != nil {
-				log.Errorf("msg can't write to connection: %v", err)
+				logger.Error("msg can't write to connection", "err", err)
 				break loop
 			}
 			c.Response().Flush()
@@ -250,13 +250,7 @@ loop:
 				messageHash = hex.EncodeToString(contentHash[:])
 			}
 
-			logrus.WithFields(logrus.Fields{
-				"hash":     messageHash,
-				"from":     fromId,
-				"to":       toId,
-				"event_id": msg.EventId,
-				"trace_id": traceID,
-			}).Debug("message sent")
+			slog.Debug("message sent", "hash", messageHash, "from", fromId, "to", toId, "event_id", msg.EventId, "trace_id", traceID)
 
 			if h.eventCollector != nil {
 				_ = h.eventCollector.TryAdd(h.eventBuilder.NewBridgeMessageSentEvent(
@@ -271,19 +265,18 @@ loop:
 		case <-ticker.C:
 			_, err = fmt.Fprint(c.Response(), heartbeatMsg)
 			if err != nil {
-				log.Errorf("ticker can't write heartbeat to connection: %v", err)
+				logger.Error("ticker can't write heartbeat to connection", "err", err)
 			}
 			c.Response().Flush()
 		}
 	}
 	activeConnectionMetric.Dec()
-	log.Info("connection closed")
+	logger.Info("connection closed")
 	return nil
 }
 
 func (h *handler) SendMessageHandler(c echo.Context) error {
-	ctx := c.Request().Context()
-	log := logrus.WithContext(ctx).WithField("prefix", "SendMessageHandler")
+	logger := slog.With("prefix", "SendMessageHandler")
 
 	params := c.QueryParams()
 
@@ -298,7 +291,7 @@ func (h *handler) SendMessageHandler(c echo.Context) error {
 	if !ok {
 		badRequestMetric.Inc()
 		errorMsg := "param \"client_id\" not present"
-		log.Error(errorMsg)
+		logger.Error(errorMsg)
 		return h.failValidation(c, errorMsg, "", traceId, "", "")
 	}
 
@@ -306,7 +299,7 @@ func (h *handler) SendMessageHandler(c echo.Context) error {
 	if err != nil {
 		err = fmt.Errorf("failed to parse the \"client_id\" address: %w", err)
 		badRequestMetric.Inc()
-		log.Error(err)
+		logger.Error(err.Error())
 		return h.failValidation(c, err.Error(), clientIdValues[0], traceId, "", "")
 	}
 
@@ -314,7 +307,7 @@ func (h *handler) SendMessageHandler(c echo.Context) error {
 	if !ok {
 		badRequestMetric.Inc()
 		errorMsg := "param \"to\" not present"
-		log.Error(errorMsg)
+		logger.Error(errorMsg)
 		return h.failValidation(c, errorMsg, clientID.String(), traceId, "", "")
 	}
 
@@ -322,7 +315,7 @@ func (h *handler) SendMessageHandler(c echo.Context) error {
 	if err != nil {
 		err = fmt.Errorf("failed to parse the \"to\" address: %w", err)
 		badRequestMetric.Inc()
-		log.Error(err)
+		logger.Error(err.Error())
 		return h.failValidation(c, err.Error(), clientID.String(), traceId, "", "")
 	}
 
@@ -330,25 +323,25 @@ func (h *handler) SendMessageHandler(c echo.Context) error {
 	if !ok {
 		badRequestMetric.Inc()
 		errorMsg := "param \"ttl\" not present"
-		log.Error(errorMsg)
+		logger.Error(errorMsg)
 		return h.failValidation(c, errorMsg, clientID.String(), traceId, "", "")
 	}
 	ttl, err := strconv.ParseInt(ttlParam[0], 10, 32)
 	if err != nil {
 		badRequestMetric.Inc()
-		log.Error(err)
+		logger.Error(err.Error())
 		return h.failValidation(c, err.Error(), clientID.String(), traceId, "", "")
 	}
 	if ttl > 300 { // TODO: config MaxTTL value
 		badRequestMetric.Inc()
 		errorMsg := "param \"ttl\" too high"
-		log.Error(errorMsg)
+		logger.Error(errorMsg)
 		return h.failValidation(c, errorMsg, clientID.String(), traceId, "", "")
 	}
 	message, err := io.ReadAll(c.Request().Body)
 	if err != nil {
 		badRequestMetric.Inc()
-		log.Error(err)
+		logger.Error(err.Error())
 		return h.failValidation(c, err.Error(), clientID.String(), traceId, "", "")
 	}
 
@@ -382,7 +375,7 @@ func (h *handler) SendMessageHandler(c echo.Context) error {
 	})
 	if err != nil {
 		badRequestMetric.Inc()
-		log.Error(err)
+		logger.Error(err.Error())
 		return h.failValidation(c, err.Error(), clientID.String(), traceId, topic, "")
 	}
 
@@ -394,11 +387,11 @@ func (h *handler) SendMessageHandler(c echo.Context) error {
 
 	// Send message only to storage - pub-sub will handle distribution
 	go func() {
-		log := log.WithField("prefix", "SendMessageHandler.storage.Pub")
+		logger := logger.With("prefix", "SendMessageHandler.storage.Pub")
 		err = h.storage.Pub(context.Background(), sseMessage, ttl)
 		if err != nil {
 			// TODO ooops
-			log.Errorf("db error: %v", err)
+			logger.Error("db error", "err", err)
 		}
 	}()
 
@@ -414,13 +407,7 @@ func (h *handler) SendMessageHandler(c echo.Context) error {
 		messageHash = hex.EncodeToString(contentHash[:])
 	}
 
-	log.WithFields(logrus.Fields{
-		"hash":     messageHash,
-		"from":     fromId,
-		"to":       toId[0],
-		"event_id": sseMessage.EventId,
-		"trace_id": traceId,
-	}).Debug("message received")
+	logger.Debug("message received", "hash", messageHash, "from", fromId, "to", toId[0], "event_id", sseMessage.EventId, "trace_id", traceId)
 
 	if h.eventCollector != nil {
 		_ = h.eventCollector.TryAdd(h.eventBuilder.NewBridgeMessageReceivedEvent(
@@ -530,14 +517,14 @@ func (h *handler) ConnectVerifyHandler(c echo.Context) error {
 }
 
 func (h *handler) removeConnection(ses *Session, traceID string) {
-	log := logrus.WithField("prefix", "removeConnection")
-	log.Infof("remove session: %v", ses.ClientIds)
+	logger := slog.With("prefix", "removeConnection")
+	logger.Info("remove session", "client_ids", ses.ClientIds)
 	for _, id := range ses.ClientIds {
 		h.Mux.RLock()
 		s, ok := h.Connections[id]
 		h.Mux.RUnlock()
 		if !ok {
-			log.Info("alredy removed")
+			logger.Info("alredy removed")
 			continue
 		}
 		s.mux.Lock()
@@ -563,8 +550,8 @@ func (h *handler) removeConnection(ses *Session, traceID string) {
 }
 
 func (h *handler) CreateSession(clientIds []string, lastEventId int64, traceID string) *Session {
-	log := logrus.WithField("prefix", "CreateSession")
-	log.Infof("make new session with ids: %v", clientIds)
+	logger := slog.With("prefix", "CreateSession")
+	logger.Info("make new session", "client_ids", clientIds)
 	session := NewSession(h.storage, clientIds, lastEventId)
 	activeConnectionMetric.Inc()
 	for _, id := range clientIds {

--- a/internal/v3/handler/session.go
+++ b/internal/v3/handler/session.go
@@ -2,9 +2,9 @@ package handlerv3
 
 import (
 	"context"
+	"log/slog"
 	"sync"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/ton-connect/bridge/internal/models"
 	"github.com/ton-connect/bridge/internal/v3/storage"
 )
@@ -39,13 +39,13 @@ func (s *Session) GetMessages() <-chan models.SseMessage {
 // Close stops the session and cleans up resources. Safe to call multiple times.
 func (s *Session) Close() {
 	s.closeOnce.Do(func() {
-		log := log.WithField("prefix", "Session.Close")
+		logger := slog.With("prefix", "Session.Close")
 		s.mux.Lock()
 		defer s.mux.Unlock()
 
 		err := s.storage.Unsub(context.Background(), s.ClientIds, s.messageCh)
 		if err != nil {
-			log.Errorf("failed to unsubscribe from storage: %v", err)
+			logger.Error("failed to unsubscribe from storage", "err", err)
 		}
 
 		close(s.Closer)

--- a/internal/v3/storage/mem.go
+++ b/internal/v3/storage/mem.go
@@ -8,9 +8,10 @@ import (
 	"sync"
 	"time"
 
+	"log/slog"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
-	"github.com/sirupsen/logrus"
 	"github.com/ton-connect/bridge/internal/analytics"
 	"github.com/ton-connect/bridge/internal/models"
 )
@@ -91,13 +92,7 @@ func (s *MemStorage) watcher() {
 					messageHash = hex.EncodeToString(contentHash[:])
 				}
 				expiredMessagesMetric.Inc()
-				logrus.WithFields(map[string]interface{}{
-					"hash":     messageHash,
-					"from":     fromID,
-					"to":       key,
-					"event_id": m.EventId,
-					"trace_id": bridgeMsg.TraceId,
-				}).Debug("message expired")
+				slog.Debug("message expired", "hash", messageHash, "from", fromID, "to", key, "event_id", m.EventId, "trace_id", bridgeMsg.TraceId)
 
 				_ = s.analytics.TryAdd(s.eventBuilder.NewBridgeMessageExpiredEvent(
 					key,

--- a/internal/v3/storage/valkey.go
+++ b/internal/v3/storage/valkey.go
@@ -145,7 +145,7 @@ func (s *ValkeyStorage) Pub(ctx context.Context, message models.SseMessage, ttl 
 	// Set expiration on the key itself
 	s.client.Expire(ctx, channel, time.Duration(ttl+60)*time.Second) // TODO remove 60 seconds buffer?
 
-	logger.Debug("published and stored message", "client", message.To, "ttl", ttl)
+	logger.Debug("published and stored message", "client_id", message.To, "ttl", ttl)
 	return nil
 }
 
@@ -177,7 +177,7 @@ func (s *ValkeyStorage) Sub(ctx context.Context, keys []string, lastEventId int6
 		messages, err := s.client.ZRange(ctx, clientKey, 0, -1).Result()
 		if err != nil {
 			if err != redis.Nil {
-				logger.Error("failed to get historical messages", "client", key, "err", err)
+				logger.Error("failed to get historical messages", "client_id", key, "err", err)
 			}
 			continue // No messages for this client or error occurred
 		}
@@ -333,7 +333,7 @@ func (s *ValkeyStorage) AddConnection(ctx context.Context, conn ConnectionInfo, 
 		return fmt.Errorf("failed to store connection: %w", err)
 	}
 
-	logger.Debug("stored connection", "client", conn.ClientID, "ip", conn.IP)
+	logger.Debug("stored connection", "client_id", conn.ClientID, "ip", conn.IP)
 	return nil
 }
 
@@ -349,7 +349,7 @@ func (s *ValkeyStorage) VerifyConnection(ctx context.Context, conn ConnectionInf
 		return "", fmt.Errorf("failed to check connection existence: %w", err)
 	}
 	if exists > 0 {
-		logger.Debug("connection verified OK", "client", conn.ClientID)
+		logger.Debug("connection verified OK", "client_id", conn.ClientID)
 		return "ok", nil
 	}
 
@@ -358,14 +358,14 @@ func (s *ValkeyStorage) VerifyConnection(ctx context.Context, conn ConnectionInf
 	keys, err := s.client.SMembers(ctx, indexKey).Result()
 	if err != nil {
 		if err == redis.Nil {
-			logger.Debug("no cached connections", "client", conn.ClientID)
+			logger.Debug("no cached connections", "client_id", conn.ClientID)
 			return "unknown", nil
 		}
 		return "", fmt.Errorf("failed to get connection index: %w", err)
 	}
 
 	if len(keys) == 0 {
-		logger.Debug("no cached connections", "client", conn.ClientID)
+		logger.Debug("no cached connections", "client_id", conn.ClientID)
 		return "unknown", nil
 	}
 
@@ -390,7 +390,7 @@ func (s *ValkeyStorage) VerifyConnection(ctx context.Context, conn ConnectionInf
 		}
 	}
 
-	logger.Debug("connection verification result", "result", leastSuspicious, "client", conn.ClientID)
+	logger.Debug("connection verification result", "result", leastSuspicious, "client_id", conn.ClientID)
 	return leastSuspicious, nil
 }
 

--- a/internal/v3/storage/valkey.go
+++ b/internal/v3/storage/valkey.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"net/url"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/redis/go-redis/v9"
-	log "github.com/sirupsen/logrus"
 	"github.com/ton-connect/bridge/internal/models"
 )
 
@@ -25,7 +25,7 @@ type ValkeyStorage struct {
 // Expects a Redis cluster URL (parsed by redis.ParseURL) and requires
 // Redis Cluster + Redis 7+ sharded pub/sub. Returns *ValkeyStorage or error.
 func NewValkeyStorage(valkeyURI string) (*ValkeyStorage, error) {
-	log := log.WithField("prefix", "NewValkeyStorage")
+	logger := slog.With("prefix", "NewValkeyStorage")
 
 	opts, err := redis.ParseURL(strings.TrimSpace(valkeyURI))
 	if err != nil {
@@ -63,7 +63,7 @@ func NewValkeyStorage(valkeyURI string) (*ValkeyStorage, error) {
 		return nil, fmt.Errorf("redis server does not support sharded pub/sub; requires redis >= 7.0")
 	}
 
-	log.Info("Successfully connected to Valkey/Redis")
+	logger.Info("Successfully connected to Valkey/Redis")
 
 	return &ValkeyStorage{
 		client:      clusterClient,
@@ -76,7 +76,7 @@ func detectClusterMode(opts *redis.Options) error {
 	client := redis.NewClient(opts)
 	defer func() {
 		if err := client.Close(); err != nil {
-			log.WithField("prefix", "detectClusterMode").Warnf("failed to close temp redis client: %v", err)
+			slog.With("prefix", "detectClusterMode").Warn("failed to close temp redis client", "err", err)
 		}
 	}()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -102,22 +102,22 @@ func supportsShardedPubSub(ctx context.Context, client redis.UniversalClient) bo
 
 // logDiscoveredNodes logs all master nodes discovered by go-redis (for debugging/monitoring)
 func logDiscoveredNodes(ctx context.Context, client *redis.ClusterClient) {
-	log := log.WithField("prefix", "ValkeyStorage.logDiscoveredNodes")
+	logger := slog.With("prefix", "ValkeyStorage.logDiscoveredNodes")
 
 	err := client.ForEachMaster(ctx, func(ctx context.Context, c *redis.Client) error {
 		opts := c.Options()
-		log.Infof("Discovered master node: %s", opts.Addr)
+		logger.Info("Discovered master node", "addr", opts.Addr)
 		return nil
 	})
 
 	if err != nil {
-		log.Warnf("Failed to enumerate cluster nodes: %v", err)
+		logger.Warn("Failed to enumerate cluster nodes", "err", err)
 	}
 }
 
 // Pub publishes a message to Redis and stores it with TTL
 func (s *ValkeyStorage) Pub(ctx context.Context, message models.SseMessage, ttl int64) error {
-	log := log.WithField("prefix", "ValkeyStorage.Pub")
+	logger := slog.With("prefix", "ValkeyStorage.Pub")
 
 	// Publish to Redis channel
 	channel := fmt.Sprintf("client:%s", message.To)
@@ -145,13 +145,13 @@ func (s *ValkeyStorage) Pub(ctx context.Context, message models.SseMessage, ttl 
 	// Set expiration on the key itself
 	s.client.Expire(ctx, channel, time.Duration(ttl+60)*time.Second) // TODO remove 60 seconds buffer?
 
-	log.Debugf("published and stored message for client %s with TTL %d seconds", message.To, ttl)
+	logger.Debug("published and stored message", "client", message.To, "ttl", ttl)
 	return nil
 }
 
 // Sub subscribes to Redis channels for the given keys and sends historical messages after lastEventId
 func (s *ValkeyStorage) Sub(ctx context.Context, keys []string, lastEventId int64, messageCh chan<- models.SseMessage) error {
-	log := log.WithField("prefix", "ValkeyStorage.Sub")
+	logger := slog.With("prefix", "ValkeyStorage.Sub")
 
 	s.subMutex.Lock()
 	defer s.subMutex.Unlock()
@@ -177,7 +177,7 @@ func (s *ValkeyStorage) Sub(ctx context.Context, keys []string, lastEventId int6
 		messages, err := s.client.ZRange(ctx, clientKey, 0, -1).Result()
 		if err != nil {
 			if err != redis.Nil {
-				log.Errorf("failed to get historical messages for client %s: %v", key, err)
+				logger.Error("failed to get historical messages", "client", key, "err", err)
 			}
 			continue // No messages for this client or error occurred
 		}
@@ -187,7 +187,7 @@ func (s *ValkeyStorage) Sub(ctx context.Context, keys []string, lastEventId int6
 			var msg models.SseMessage
 			err := json.Unmarshal([]byte(msgData), &msg)
 			if err != nil {
-				log.Errorf("failed to unmarshal historical message: %v", err)
+				logger.Error("failed to unmarshal historical message", "err", err)
 				continue
 			}
 
@@ -216,17 +216,17 @@ func (s *ValkeyStorage) Sub(ctx context.Context, keys []string, lastEventId int6
 		// Subscribe to additional channels
 		err := s.pubSubConn.Subscribe(ctx, channels...)
 		if err != nil {
-			log.Errorf("failed to subscribe to additional channels: %v", err)
+			logger.Error("failed to subscribe to additional channels", "err", err)
 		}
 	}
 
-	log.Debugf("subscribed to channels for keys: %v", keys)
+	logger.Debug("subscribed to channels for keys", "keys", keys)
 	return nil
 }
 
 // Unsub unsubscribes from Redis channels for the given keys
 func (s *ValkeyStorage) Unsub(ctx context.Context, keys []string, messageCh chan<- models.SseMessage) error {
-	log := log.WithField("prefix", "ValkeyStorage.Unsub")
+	logger := slog.With("prefix", "ValkeyStorage.Unsub")
 
 	s.subMutex.Lock()
 	defer s.subMutex.Unlock()
@@ -266,13 +266,13 @@ func (s *ValkeyStorage) Unsub(ctx context.Context, keys []string, messageCh chan
 		}
 	}
 
-	log.Debugf("unsubscribed messageCh from keys: %v (redis channels unsubbed: %v)", keys, channelsToUnsub)
+	logger.Debug("unsubscribed messageCh from keys", "keys", keys, "redis_channels_unsubbed", channelsToUnsub)
 	return nil
 }
 
 // handlePubSub processes incoming Redis pub-sub messages
 func (s *ValkeyStorage) handlePubSub() {
-	log := log.WithField("prefix", "ValkeyStorage.handlePubSub")
+	logger := slog.With("prefix", "ValkeyStorage.handlePubSub")
 
 	for msg := range s.pubSubConn.Channel() {
 		// Parse channel name to get client key
@@ -287,7 +287,7 @@ func (s *ValkeyStorage) handlePubSub() {
 		var sseMessage models.SseMessage
 		err := json.Unmarshal([]byte(msg.Payload), &sseMessage)
 		if err != nil {
-			log.Errorf("failed to unmarshal pub-sub message: %v", err)
+			logger.Error("failed to unmarshal pub-sub message", "err", err)
 			continue
 		}
 
@@ -310,7 +310,7 @@ func (s *ValkeyStorage) handlePubSub() {
 // AddConnection stores connection info in Valkey with TTL
 // Key pattern: conn:full:{clientID}:{ip}:{urlEncodedOrigin}
 func (s *ValkeyStorage) AddConnection(ctx context.Context, conn ConnectionInfo, ttl time.Duration) error {
-	log := log.WithField("prefix", "ValkeyStorage.AddConnection")
+	logger := slog.With("prefix", "ValkeyStorage.AddConnection")
 
 	key := fmt.Sprintf("conn:full:%s:%s:%s", conn.ClientID, conn.IP, url.QueryEscape(conn.Origin))
 
@@ -333,14 +333,14 @@ func (s *ValkeyStorage) AddConnection(ctx context.Context, conn ConnectionInfo, 
 		return fmt.Errorf("failed to store connection: %w", err)
 	}
 
-	log.Debugf("stored connection for client %s from %s", conn.ClientID, conn.IP)
+	logger.Debug("stored connection", "client", conn.ClientID, "ip", conn.IP)
 	return nil
 }
 
 // VerifyConnection checks if connection matches cached data
 // Returns: "ok" (exact match), "warning" (same origin different IP), "danger" (different origin), or "unknown" (no cached data)
 func (s *ValkeyStorage) VerifyConnection(ctx context.Context, conn ConnectionInfo) (string, error) {
-	log := log.WithField("prefix", "ValkeyStorage.VerifyConnection")
+	logger := slog.With("prefix", "ValkeyStorage.VerifyConnection")
 
 	// Check for exact match first
 	exactKey := fmt.Sprintf("conn:full:%s:%s:%s", conn.ClientID, conn.IP, url.QueryEscape(conn.Origin))
@@ -349,7 +349,7 @@ func (s *ValkeyStorage) VerifyConnection(ctx context.Context, conn ConnectionInf
 		return "", fmt.Errorf("failed to check connection existence: %w", err)
 	}
 	if exists > 0 {
-		log.Debugf("connection verified OK for client %s", conn.ClientID)
+		logger.Debug("connection verified OK", "client", conn.ClientID)
 		return "ok", nil
 	}
 
@@ -358,14 +358,14 @@ func (s *ValkeyStorage) VerifyConnection(ctx context.Context, conn ConnectionInf
 	keys, err := s.client.SMembers(ctx, indexKey).Result()
 	if err != nil {
 		if err == redis.Nil {
-			log.Debugf("no cached connections for client %s", conn.ClientID)
+			logger.Debug("no cached connections", "client", conn.ClientID)
 			return "unknown", nil
 		}
 		return "", fmt.Errorf("failed to get connection index: %w", err)
 	}
 
 	if len(keys) == 0 {
-		log.Debugf("no cached connections for client %s", conn.ClientID)
+		logger.Debug("no cached connections", "client", conn.ClientID)
 		return "unknown", nil
 	}
 
@@ -381,7 +381,7 @@ func (s *ValkeyStorage) VerifyConnection(ctx context.Context, conn ConnectionInf
 		encodedOrigin := parts[4]
 		cachedOrigin, err := url.QueryUnescape(encodedOrigin)
 		if err != nil {
-			log.Warnf("failed to decode origin from key %s: %v", key, err)
+			logger.Warn("failed to decode origin from key", "key", key, "err", err)
 			continue
 		}
 
@@ -390,13 +390,13 @@ func (s *ValkeyStorage) VerifyConnection(ctx context.Context, conn ConnectionInf
 		}
 	}
 
-	log.Debugf("connection verification result: %s for client %s", leastSuspicious, conn.ClientID)
+	logger.Debug("connection verification result", "result", leastSuspicious, "client", conn.ClientID)
 	return leastSuspicious, nil
 }
 
 // HealthCheck verifies the connection to Valkey
 func (s *ValkeyStorage) HealthCheck() error {
-	log := log.WithField("prefix", "ValkeyStorage.HealthCheck")
+	logger := slog.With("prefix", "ValkeyStorage.HealthCheck")
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
@@ -406,6 +406,6 @@ func (s *ValkeyStorage) HealthCheck() error {
 		return fmt.Errorf("valkey health check failed: %w", err)
 	}
 
-	log.Info("Valkey is healthy")
+	logger.Info("Valkey is healthy")
 	return nil
 }

--- a/tonmetrics/analytics.go
+++ b/tonmetrics/analytics.go
@@ -5,10 +5,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"net/http"
+	"os"
 	"time"
 
-	"github.com/sirupsen/logrus"
 	"github.com/ton-connect/bridge/internal/config"
 )
 
@@ -35,7 +36,8 @@ func NewAnalyticsClient() AnalyticsClient {
 		return NewNoopMetricsClient(configuredAnalyticsURL)
 	}
 	if config.Config.TonAnalyticsNetworkId != "-239" && config.Config.TonAnalyticsNetworkId != "-3" {
-		logrus.Fatalf("invalid NETWORK_ID '%s'. Allowed values: -239 (mainnet) and -3 (testnet)", config.Config.TonAnalyticsNetworkId)
+		slog.Error("invalid NETWORK_ID, allowed values are -239 (mainnet) and -3 (testnet)", "network_id", config.Config.TonAnalyticsNetworkId)
+		os.Exit(1)
 	}
 	return &TonMetricsClient{
 		client:       http.DefaultClient,
@@ -58,16 +60,16 @@ func (a *TonMetricsClient) send(ctx context.Context, events []interface{}, endpo
 		return nil
 	}
 
-	log := logrus.WithField("prefix", prefix)
+	logger := slog.With("prefix", prefix)
 
-	log.Debugf("preparing to send analytics batch of %d events to %s", len(events), endpoint)
+	logger.Debug("preparing to send analytics batch", "count", len(events), "endpoint", endpoint)
 
 	analyticsData, err := json.Marshal(events)
 	if err != nil {
 		return fmt.Errorf("failed to marshal analytics batch: %w", err)
 	}
 
-	log.Debugf("marshaled analytics data size: %d bytes", len(analyticsData))
+	logger.Debug("marshaled analytics data", "bytes", len(analyticsData))
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(analyticsData))
 	if err != nil {
@@ -77,7 +79,7 @@ func (a *TonMetricsClient) send(ctx context.Context, events []interface{}, endpo
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("X-Client-Timestamp", fmt.Sprintf("%d", time.Now().Unix()))
 
-	log.Debugf("sending analytics batch request to %s", endpoint)
+	logger.Debug("sending analytics batch request", "endpoint", endpoint)
 
 	resp, err := a.client.Do(req)
 	if err != nil {
@@ -85,7 +87,7 @@ func (a *TonMetricsClient) send(ctx context.Context, events []interface{}, endpo
 	}
 	defer func() {
 		if closeErr := resp.Body.Close(); closeErr != nil {
-			log.Errorf("failed to close response body: %v", closeErr)
+			logger.Error("failed to close response body", "err", closeErr)
 		}
 	}()
 
@@ -93,7 +95,7 @@ func (a *TonMetricsClient) send(ctx context.Context, events []interface{}, endpo
 		return fmt.Errorf("analytics batch request to %s returned status %d", endpoint, resp.StatusCode)
 	}
 
-	log.Debugf("analytics batch of %d events sent successfully with status %d", len(events), resp.StatusCode)
+	logger.Debug("analytics batch sent", "count", len(events), "status", resp.StatusCode)
 	return nil
 }
 


### PR DESCRIPTION
Unify the bridge's structured logging on the standard library log/slog. Migrate the v3 service path and shared packages off logrus; v1 stays on logrus for now. Output remains JSON with consistent fields.