### PR TITLE
fix: store message synchronously before acking send

### DIFF
--- a/internal/v1/handler/handler.go
+++ b/internal/v1/handler/handler.go
@@ -440,14 +440,13 @@ func (h *handler) SendMessageHandler(c echo.Context) error {
 		}
 		s.mux.Unlock()
 	}
-	go func() {
-		log := log.WithField("prefix", "SendMessageHandler.storge.Add")
-		err = h.storage.Add(context.Background(), sseMessage, ttl)
-		if err != nil {
-			// TODO ooops
-			log.Errorf("db error: %v", err)
-		}
-	}()
+	// Persist before acknowledging: a client reconnecting right after the 200 must find this
+	// message in the backlog, so the store has to complete before the response. Background
+	// context keeps persistence alive even if the sender disconnects.
+	if err := h.storage.Add(context.Background(), sseMessage, ttl); err != nil {
+		log.WithField("prefix", "SendMessageHandler.storage.Add").Errorf("db error: %v", err)
+		return c.JSON(utils.HttpResError("failed to store message", http.StatusInternalServerError))
+	}
 
 	var bridgeMsg models.BridgeMessage
 	fromId := "unknown"

--- a/internal/v3/handler/handler.go
+++ b/internal/v3/handler/handler.go
@@ -385,15 +385,13 @@ func (h *handler) SendMessageHandler(c echo.Context) error {
 		To:      toId.String(),
 	}
 
-	// Send message only to storage - pub-sub will handle distribution
-	go func() {
-		logger := slog.With("prefix", "SendMessageHandler.storage.Pub")
-		err = h.storage.Pub(context.Background(), sseMessage, ttl)
-		if err != nil {
-			// TODO ooops
-			logger.Error("db error", "err", err)
-		}
-	}()
+	// Persist before acknowledging: a client reconnecting right after the 200 must find this
+	// message in the backlog, so the store has to complete before the response. Background
+	// context keeps persistence alive even if the sender disconnects.
+	if err := h.storage.Pub(context.Background(), sseMessage, ttl); err != nil {
+		slog.With("prefix", "SendMessageHandler.storage.Pub").Error("db error", "err", err)
+		return c.JSON(utils.HttpResError("failed to store message", http.StatusInternalServerError))
+	}
 
 	var bridgeMsg models.BridgeMessage
 	fromId := "unknown"

--- a/test/gointegration/bridge_gateway_test.go
+++ b/test/gointegration/bridge_gateway_test.go
@@ -320,8 +320,11 @@ func getBridgeLastEventID(t *testing.T, sender *BridgeGateway, senderSession str
 		}
 	}()
 
-	if !receiver.IsReady() {
-		t.Fatal("receiver not ready")
+	// WaitReady, not IsReady: IsReady is true as soon as the SSE response is open, but the
+	// server registers the subscription a moment later (session.Start), so a send racing that
+	// window is dropped. WaitReady adds the settle the live-delivery path needs.
+	if err := receiver.WaitReady(ctx); err != nil {
+		t.Fatalf("receiver not ready: %v", err)
 	}
 
 	if err := sender.Send(ctx, make([]byte, 0), senderSession, session, nil); err != nil {
@@ -432,8 +435,10 @@ func TestBridge_NoMessageAfterReconnectWithUpdatedLastEventID(t *testing.T) {
 	if err != nil {
 		t.Fatalf("open receiver1: %v", err)
 	}
-	if !r1.IsReady() {
-		t.Fatal("receiver1 not ready")
+	// WaitReady, not IsReady: r1 must receive "Hello!" live, so the server-side subscription
+	// has to be established before the send (see WaitReady note above).
+	if err := r1.WaitReady(ctx); err != nil {
+		t.Fatalf("receiver1 not ready: %v", err)
 	}
 	if err := sender.Send(ctx, []byte("Hello!"), senderSession, session, nil); err != nil {
 		t.Fatalf("send: %v", err)


### PR DESCRIPTION
The reconnect integration tests flaked across storage variants because the bridge gave no happens-before guarantee between a `POST /bridge/message` returning 200 and that message becoming readable. Two independent races sat behind the flake.

**Store-and-forward / backlog replay.** The send handler delivered the message to live subscribers and returned 200 while the backlog write ran in a detached goroutine. A client reconnecting right after the 200 could read the backlog before that write landed, so the message was neither replayed from storage nor delivered live, and the caller hung until its deadline. Both the v3 (valkey) and v1 (postgres) handlers now persist synchronously before responding and return 500 when the store fails, using a background context so a sender disconnecting mid-request cannot abort persistence.

**Live delivery.** Two tests checked `IsReady()`, which is true the moment the SSE response opens, before a send they expect to receive live. The server registers the subscription a moment later in `session.Start()`, so a send racing that window was dropped. They now wait on `WaitReady()`, which adds the settle the live-delivery path needs.