### PR TITLE
fix: set SSE reconnect delay to 100ms

### DIFF
--- a/internal/v1/handler/handler.go
+++ b/internal/v1/handler/handler.go
@@ -116,7 +116,7 @@ func (h *handler) EventRegistrationHandler(c echo.Context) error {
 	c.Response().Header().Set("Transfer-Encoding", "chunked")
 	c.Response().Header().Set("X-Accel-Buffering", "no")
 	c.Response().WriteHeader(http.StatusOK)
-	_, _ = fmt.Fprint(c.Response(), "\n")
+	_, _ = fmt.Fprint(c.Response(), "retry: 100\n\n")
 	c.Response().Flush()
 
 	paramsStore, err := handler_common.NewParamsStorage(c, config.Config.MaxBodySize)

--- a/internal/v3/handler/handler.go
+++ b/internal/v3/handler/handler.go
@@ -104,8 +104,8 @@ func (h *handler) EventRegistrationHandler(c echo.Context) error {
 	c.Response().Header().Set("Transfer-Encoding", "chunked")
 	c.Response().Header().Set("X-Accel-Buffering", "no")
 	c.Response().WriteHeader(http.StatusOK)
-	if _, err := fmt.Fprint(c.Response(), "\n"); err != nil {
-		logger.Error("failed to write initial newline", "err", err)
+	if _, err := fmt.Fprint(c.Response(), "retry: 100\n\n"); err != nil {
+		logger.Error("failed to write initial SSE frame", "err", err)
 		return err
 	}
 	c.Response().Flush()


### PR DESCRIPTION
## Summary

Send `retry: 100\n\n` instead of the initial blank line in both v1 and v3 SSE handlers, using the existing immediate flush. Update the v3 write-error message to describe the new initial frame.

This tells native `EventSource` clients to use a 100 ms reconnection interval. Without an explicit SSE `retry` field, [WebKit defaults to 3000 ms](https://github.com/WebKit/WebKit/blob/96cf89c2cbc71ab5f92161b3989b0fed6fb84e10/Source/WebCore/page/EventSource.cpp#L66), which can add a noticeable delay when a backgrounded wallet reconnects.
