### PR TITLE
release: bump bridge to 07a091a (slog, synchronous store, SSE retry)

### DIFF
--- a/version.yaml
+++ b/version.yaml
@@ -2,4 +2,4 @@
 # Changes to this file intentionally do not trigger image builds.
 release:
   branch: master
-  sha: bc97ab0
+  sha: 07a091a


### PR DESCRIPTION
Points the published deployment at `07a091a`, which carries everything merged since the pointer last moved: `#232` (v3 and the shared packages on `log/slog`), `#235` (CI re-tags the release image onto non-building commits), `#233` (a message is stored before the send is acked) and `#246` (SSE reconnect delay of 100ms). Pointer-only change, no code; the image for this sha is already in ECR, and verify-release-pointer gates schema, provenance and image existence.

Three of those change behaviour a reader of the subjects would not expect, so they are worth naming before the roll.

`POST /bridge/message` now persists synchronously and answers 500 when the store fails, where it previously returned 200 from a detached goroutine and could lose the message silently. That makes Valkey availability visible to the sender, and it puts three round trips on the response path with no deadline of their own. `/readyz` does not consult Valkey, so a degraded store leaves pods Ready and answering 500 rather than leaving the load balancer. A partial failure - `Publish` through, `ZAdd` not - delivers to live subscribers, answers 500, and a sender that retries produces a duplicate under a new event id.

The SSE stream now opens with `retry: 100`. Steady state is unaffected: heartbeats run every 10s against a 60s ALB idle timeout, and streams end on their own 2h lifetime with 15 minutes of jitter. Under a rolling update, both pods' clients reconnect within a 100ms window instead of the several seconds a user agent picks by default; under sustained 5xx, an EventSource keeps that interval for its lifetime and the rate limiter skips `/bridge/events` entirely.

The log format changes with the slog migration: uppercase levels, `err` in place of `error`, constant messages with the interpolated values moved into fields, and stdout instead of stderr. Level case is normalised in the collector, so what lands in storage is unchanged.